### PR TITLE
Make aliases constant

### DIFF
--- a/src/AtmosParameters.jl
+++ b/src/AtmosParameters.jl
@@ -1,4 +1,4 @@
-AtmosSGS = CLIMAParameters.Atmos.SubgridScale
+const AtmosSGS = CLIMAParameters.Atmos.SubgridScale
 
 # SubgridScale parameters
 AtmosSGS.C_smag(::AbstractEarthParameterSet)            = 0.21
@@ -13,7 +13,7 @@ AtmosSGS.c_2_KASM(ps::AbstractEarthParameterSet)        = AtmosSGS.c_e2_KASM(ps)
 AtmosSGS.c_3_KASM(ps::AbstractEarthParameterSet)        = AtmosSGS.c_a_KASM(ps)^(3/2)
 
 # Microphysics parameters
-Microphysics = CLIMAParameters.Atmos.Microphysics
+const Microphysics = CLIMAParameters.Atmos.Microphysics
 
 # general
 Microphysics.C_drag(::AbstractEarthParameterSet)  = 0.55

--- a/src/PlanetParameters.jl
+++ b/src/PlanetParameters.jl
@@ -1,6 +1,6 @@
 
 # Properties of dry air
-Planet = CLIMAParameters.Planet
+const Planet = CLIMAParameters.Planet
 Planet.molmass_dryair(ps::AbstractEarthParameterSet) = 28.97e-3
 Planet.R_d(ps::AbstractEarthParameterSet)            = gas_constant() / Planet.molmass_dryair(ps)
 Planet.kappa_d(ps::AbstractEarthParameterSet)        = 2 / 7

--- a/src/SubgridScaleParameters.jl
+++ b/src/SubgridScaleParameters.jl
@@ -1,4 +1,4 @@
 # SubgridScale parameters
-SubgridScale = CLIMAParameters.SubgridScale
+const SubgridScale = CLIMAParameters.SubgridScale
 SubgridScale.von_karman_const(ps::AbstractEarthParameterSet)        = 0.4
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -142,3 +142,11 @@ end
 
 end
 
+import CLIMAParameters
+CLIMAParameters.Planet.grav(::EarthParameterSet) = 2.0
+@testset "Overriding defaults" begin
+
+  @test grav(earth) ≈ 2.0
+
+end
+


### PR DESCRIPTION
@jkozdon discovered a performance hit, in [ClimateMachine.jl's 1176](https://github.com/CliMA/ClimateMachine.jl/issues/1176), from not using `const` for aliases in CLIMAParameters.jl. This PR adds `const` to the module aliases.

Before this PR:
```julia
julia> using InteractiveUtils;
julia> using CLIMAParameters;
julia> using CLIMAParameters.Atmos.Microphysics;
julia> struct RainParameterSet   <: AbstractRainParameterSet end;
julia> ps = RainParameterSet();
julia> @code_warntype CLIMAParameters.Microphysics.a0(ps)
Variables
  #self#::Core.Compiler.Const(CLIMAParameters.Atmos.Microphysics.a0, false)
  ps_rain::Core.Compiler.Const(RainParameterSet(), false)

Body::Any
1 ─ %1 = Base.getproperty(CLIMAParameters.Microphysics, :r0)::Any
│   %2 = (%1)(ps_rain)::Any
│   %3 = Base.getproperty(CLIMAParameters.Microphysics, :ae)::Any
│   %4 = (%3)(ps_rain)::Any
│   %5 = (%2 ^ %4)::Any
│   %6 = (CLIMAParameters.π * %5)::Any
└──      return %6
```

After this PR:
```julia
julia> using InteractiveUtils;
julia> using CLIMAParameters;
julia> using CLIMAParameters.Atmos.Microphysics;
julia> struct RainParameterSet   <: AbstractRainParameterSet end;
julia> ps = RainParameterSet();
julia> @code_warntype CLIMAParameters.Microphysics.a0(ps)
Variables
  #self#::Core.Compiler.Const(CLIMAParameters.Atmos.Microphysics.a0, false)
  ps_rain::Core.Compiler.Const(RainParameterSet(), false)

Body::Float64
1 ─ %1 = CLIMAParameters.Atmos.Microphysics.r0::Core.Compiler.Const(CLIMAParameters.Atmos.Microphysics.r0, false)
│   %2 = (%1)(ps_rain)::Core.Compiler.Const(0.001, false)
│   %3 = CLIMAParameters.Atmos.Microphysics.ae::Core.Compiler.Const(CLIMAParameters.Atmos.Microphysics.ae, false)
│   %4 = (%3)(ps_rain)::Core.Compiler.Const(2.0, false)
│   %5 = (%2 ^ %4)::Float64
│   %6 = (CLIMAParameters.π * %5)::Float64
└──      return %6
```