### PR TITLE
add 0-moment microphysics parameters

### DIFF
--- a/docs/src/API.md
+++ b/docs/src/API.md
@@ -106,6 +106,14 @@ Atmos.SubgridScale.c_2_KASM
 Atmos.SubgridScale.c_3_KASM
 ```
 
+### Microphysics_0M
+
+```@docs
+Atmos.Microphysics_0M.τ_precip
+Atmos.Microphysics_0M.qc_0
+Atmos.Microphysics_0M.S_0
+```
+
 ### Microphysics
 
 Please see the microphysics [documentation](https://clima.github.io/ClimateMachine.jl/latest/Theory/Atmos/Microphysics/) for an explanation of the default values.

--- a/src/Atmos/Atmos.jl
+++ b/src/Atmos/Atmos.jl
@@ -50,6 +50,23 @@ function c_3_KASM end
 
 end # module SubgridScale
 
+module Microphysics_0M
+
+export τ_precip,
+       qc_0,
+       S_0
+
+""" precipitation removal timescale (s) """
+function τ_precip end
+
+""" precipitation removal threshold expressed in condensate specific humidity (kg/kg) """
+function qc_0 end
+
+""" precipitation removal threshold expressed in supersaturation (dimensionless) """
+function S_0 end
+
+end # module Microphysics_0M
+
 module Microphysics
 
 export n0,

--- a/src/Atmos/atmos_parameters.jl
+++ b/src/Atmos/atmos_parameters.jl
@@ -12,7 +12,14 @@ AtmosSGS.c_1_KASM(ps::AbstractEarthParameterSet)        = AtmosSGS.c_a_KASM(ps)*
 AtmosSGS.c_2_KASM(ps::AbstractEarthParameterSet)        = AtmosSGS.c_e2_KASM(ps)+2*AtmosSGS.c_1_KASM(ps)
 AtmosSGS.c_3_KASM(ps::AbstractEarthParameterSet)        = AtmosSGS.c_a_KASM(ps)^(3/2)
 
-# Microphysics parameters
+# 0-moment microphysics parameters
+const Microphysics_0M = CLIMAParameters.Atmos.Microphysics_0M
+
+Microphysics_0M.τ_precip(::AbstractEarthParameterSet) = 1000
+Microphysics_0M.qc_0(::AbstractEarthParameterSet) = 5e-3
+Microphysics_0M.S_0(::AbstractEarthParameterSet) = 0.02
+
+# 1-moment microphysics parameters
 const Microphysics = CLIMAParameters.Atmos.Microphysics
 
 # general

--- a/test/microphysics.jl
+++ b/test/microphysics.jl
@@ -2,7 +2,19 @@ using Test
 using CLIMAParameters
 using CLIMAParameters.Planet
 
+using CLIMAParameters.Atmos.Microphysics_0M
 using CLIMAParameters.Atmos.Microphysics
+
+@testset "Microphysics_0M" begin
+
+  struct EarthParameterSet <: AbstractEarthParameterSet end
+  ps = EarthParameterSet()
+
+  @test !isnan(Microphysics_0M.τ_precip(ps))
+  @test !isnan(Microphysics_0M.qc_0(ps))
+  @test !isnan(Microphysics_0M.S_0(ps))
+
+end
 
 @testset "Microphysics" begin
 


### PR DESCRIPTION
This adds parameters needed for the GCM precipitation removal scheme (aka the 0-moment microphysics).

@charleskawczynski - it would be great to bump the version number after this is merged. 