### PR TITLE
Add some planet parameters

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CLIMAParameters"
 uuid = "6eacf6c3-8458-43b9-ae03-caf5306d3d53"
 authors = ["Charles Kawczynski <kawczynski.charles@gmail.com>"]
-version = "0.1.12"
+version = "0.1.13"
 
 [deps]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/docs/src/API.md
+++ b/docs/src/API.md
@@ -63,6 +63,9 @@ Planet.e_int_v0
 Planet.e_int_i0
 Planet.press_triple
 Planet.surface_tension_coeff
+Planet.entropy_water_vapor
+Planet.entropy_dry_air
+Planet.entropy_reference_temperature
 Planet.ρ_ocean
 Planet.cp_ocean
 Planet.planet_radius

--- a/src/Planet/Planet.jl
+++ b/src/Planet/Planet.jl
@@ -34,6 +34,9 @@ export molmass_dryair,
     e_int_i0,
     press_triple,
     surface_tension_coeff,
+    entropy_dry_air,
+    entropy_water_vapor,
+    entropy_reference_temperature,
     ρ_ocean,
     cp_ocean,
     planet_radius,
@@ -114,6 +117,23 @@ function e_int_i0 end
 function press_triple end
 """ Surface tension coefficient of water (J/m2) """
 function surface_tension_coeff end
+""" Surface tension coefficient of water (J/m2) """
+function surface_tension_coeff end
+
+#=
+The standard entropy value for dry air is computed based
+on the reference data given in Lemmon et al. [2000], and
+the standard entropy value for water vapor is based on the
+reference data given in Chase [1998].
+=#
+
+""" Entropy of dry air J / (kg K)"""
+function entropy_dry_air end
+""" Entropy of water vapor J / (kg K)"""
+function entropy_water_vapor end
+""" Entropy reference temperature (K)"""
+function entropy_reference_temperature end
+
 
 # Properties of sea water
 """ Reference density sea water (kg/m``^3``) """

--- a/src/Planet/planet_parameters.jl
+++ b/src/Planet/planet_parameters.jl
@@ -33,6 +33,10 @@ Planet.e_int_i0(ps::AbstractEarthParameterSet)              = Planet.LH_f0(ps)
 Planet.press_triple(ps::AbstractEarthParameterSet)          = 611.657
 Planet.surface_tension_coeff(ps::AbstractEarthParameterSet) = 0.072
 
+Planet.entropy_dry_air(ps::AbstractEarthParameterSet)       = 6864.8
+Planet.entropy_water_vapor(ps::AbstractEarthParameterSet)   = 10513.6
+Planet.entropy_reference_temperature(ps::AbstractEarthParameterSet)  = 298.15
+
 # Properties of sea water
 Planet.ρ_ocean(ps::AbstractEarthParameterSet)        = 1.035e3
 Planet.cp_ocean(ps::AbstractEarthParameterSet)       = 3989.25


### PR DESCRIPTION
These parameters are from "Large-eddy simulation in an anelastic framework with closed water and entropy balances" (Pressel et. al.), Table 1. This is needed for [TurbulenceConvection.jl's #43](https://github.com/CliMA/TurbulenceConvection.jl/pull/43).