### PR TITLE
Remove duplicate function

### DIFF
--- a/src/Planet/Planet.jl
+++ b/src/Planet/Planet.jl
@@ -117,8 +117,6 @@ function e_int_i0 end
 function press_triple end
 """ Surface tension coefficient of water (J/m2) """
 function surface_tension_coeff end
-""" Surface tension coefficient of water (J/m2) """
-function surface_tension_coeff end
 
 #=
 The standard entropy value for dry air is computed based


### PR DESCRIPTION
I accidentally added a duplicate function stub in #51 (which results in a documentation warning). This PR removes that duplicate function stub & doc string.