### PR TITLE
Update EDMF parameter notation.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CLIMAParameters"
 uuid = "6eacf6c3-8458-43b9-ae03-caf5306d3d53"
 authors = ["Charles Kawczynski <kawczynski.charles@gmail.com>"]
-version = "0.3.0"
+version = "0.4.0"
 
 [deps]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/docs/src/API.md
+++ b/docs/src/API.md
@@ -136,7 +136,7 @@ Atmos.SubgridScale.c_3_KASM
 Atmos.EDMF.c_λ
 Atmos.EDMF.c_ε
 Atmos.EDMF.c_δ
-Atmos.EDMF.c_t
+Atmos.EDMF.c_γ
 Atmos.EDMF.β
 Atmos.EDMF.μ_0
 Atmos.EDMF.χ

--- a/src/Atmos/Atmos.jl
+++ b/src/Atmos/Atmos.jl
@@ -55,7 +55,7 @@ module EDMF
 export c_λ,
        c_ε,
        c_δ,
-       c_t,
+       c_γ,
        β,
        μ_0,
        χ,
@@ -91,7 +91,7 @@ function c_ε end
 function c_δ end
 
 """ Turbulent Entrainment factor (dimensionless) """
-function c_t end
+function c_γ end
 
 """ Detrainment RH power (dimensionless) """
 function β end

--- a/src/Atmos/atmos_parameters.jl
+++ b/src/Atmos/atmos_parameters.jl
@@ -19,7 +19,7 @@ const EDMF = CLIMAParameters.Atmos.EDMF
 EDMF.c_λ(::AEPS)            = 0.3
 EDMF.c_ε(::AEPS)            = 0.13
 EDMF.c_δ(::AEPS)            = 0.52
-EDMF.c_t(::AEPS)            = 0.1
+EDMF.c_γ(::AEPS)            = 0.075
 EDMF.β(::AEPS)              = 2
 EDMF.μ_0(::AEPS)            = 4e-4
 EDMF.χ(::AEPS)              = 0.25
@@ -44,7 +44,7 @@ EDMF.H_up_min(::AEPS)       = 500
 # Mixing length model
 EDMF.c_d(::AEPS)            = 0.22
 EDMF.c_m(::AEPS)            = 0.14
-EDMF.c_b(::AEPS)            = 0.63
+EDMF.c_b(::AEPS)            = 0.4
 EDMF.a1(::AEPS)             = 0.2
 EDMF.a2(::AEPS)             = 100
 EDMF.ω_pr(::AEPS)           = 53.0 / 13.0

--- a/test/edmf.jl
+++ b/test/edmf.jl
@@ -10,7 +10,7 @@ using CLIMAParameters.Atmos.EDMF
   @test !isnan(EDMF.c_λ(ps))
   @test !isnan(EDMF.c_ε(ps))
   @test !isnan(EDMF.c_δ(ps))
-  @test !isnan(EDMF.c_t(ps))
+  @test !isnan(EDMF.c_γ(ps))
   @test !isnan(EDMF.β(ps))
   @test !isnan(EDMF.μ_0(ps))
   @test !isnan(EDMF.χ(ps))


### PR DESCRIPTION
Updates the naming convention for one of the EDMF parameters, following the parameter table in Cohen et al (2020). It also fixes the default value of static_stab_coefficient `c_b`.