### PR TITLE
[WIP] pilot parameter refactor (b) 

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Charles Kawczynski <kawczynski.charles@gmail.com>"]
 version = "0.4.0"
 
 [deps]
+DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 

--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,10 @@ authors = ["Charles Kawczynski <kawczynski.charles@gmail.com>"]
 version = "0.4.0"
 
 [deps]
+Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
+EnsembleKalmanProcesses = "aa8a2aa5-91d8-4396-bcef-d4f2ec43552d"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -2,6 +2,8 @@ using CLIMAParameters, Documenter
 
 pages = Any[
     "Home" => "index.md",
+    "TOML file interface" => "toml.md",
+    "Parameter structures" => "parameter_structs.md",
     "API" => "API.md",
 ]
 

--- a/docs/src/API.md
+++ b/docs/src/API.md
@@ -2,6 +2,32 @@
 
 ```@meta
 CurrentModule = CLIMAParameters
+using CLIMAParameters
+```
+
+## Parameter struct
+
+```@docs
+CLIMAParameters.ParamDict
+```
+
+## file parsing and parameter logging
+
+```@docs
+CLIMAParameters.parse_toml_file
+CLIMAParameters.get_parametric_type
+CLIMAParameters.iterate_alias
+CLIMAParameters.log_component!(param_set::ParamDict,names,component) 
+CLIMAParameters.get_values(param_set::ParamDict, names) 
+CLIMAParameters.get_parameter_values!
+CLIMAParameters.get_parameter_values
+CLIMAParameters.check_override_parameter_usage
+CLIMAParameters.write_log_file
+CLIMAParameters.log_parameter_information
+CLIMAParameters.merge_override_default_values
+CLIMAParameters.create_parameter_struct(path_to_override, path_to_default)
+CLIMAParameters.create_parameter_struct(path_to_override)
+CLIMAParameters.create_parameter_struct()
 ```
 
 ## Types

--- a/docs/src/API.md
+++ b/docs/src/API.md
@@ -2,32 +2,36 @@
 
 ```@meta
 CurrentModule = CLIMAParameters
-using CLIMAParameters
 ```
 
 ## Parameter struct
 
 ```@docs
-CLIMAParameters.ParamDict
+ParamDict
 ```
 
-## file parsing and parameter logging
+## File parsing and parameter logging
 
+### User facing functions:
 ```@docs
-CLIMAParameters.parse_toml_file
-CLIMAParameters.get_parametric_type
-CLIMAParameters.iterate_alias
-CLIMAParameters.log_component!(param_set::ParamDict,names,component) 
-CLIMAParameters.get_values(param_set::ParamDict, names) 
-CLIMAParameters.get_parameter_values!
-CLIMAParameters.get_parameter_values
-CLIMAParameters.check_override_parameter_usage
-CLIMAParameters.write_log_file
-CLIMAParameters.log_parameter_information
-CLIMAParameters.merge_override_default_values
-CLIMAParameters.create_parameter_struct(path_to_override, path_to_default)
-CLIMAParameters.create_parameter_struct(path_to_override)
-CLIMAParameters.create_parameter_struct()
+create_parameter_struct(path_to_override, path_to_default)
+create_parameter_struct(path_to_override)
+create_parameter_struct()
+get_parameter_values!
+get_parameter_values
+get_parametric_type
+log_parameter_information
+```
+
+### Internal functions:
+```@docs
+parse_toml_file
+iterate_alias
+log_component!(param_set::ParamDict,names,component) 
+get_values(param_set::ParamDict, names) 
+check_override_parameter_usage
+write_log_file
+merge_override_default_values
 ```
 
 ## Types

--- a/docs/src/parameter_structs.md
+++ b/docs/src/parameter_structs.md
@@ -1,0 +1,163 @@
+# Parameter Structures
+
+Parameters are stored in objects that reflect the model component construction. Definitions should be inserted into the model component source code
+
+## An example from `Thermodynamics.jl` 
+
+### In the user-facing driver file
+```julia
+import CLIMAParameters
+import Thermodynamics
+parameter_struct = CLIMAParameters.create_parameter_struct(dict_type="alias") 
+thermo_params = Thermodynamics.ThermodynamicsParameters(parameter_struct)
+```
+
+### In the source code for `Thermodynamics.jl`
+
+```julia
+struct ThermodynamicsParameters{FT}
+    ...
+    R_d::FT
+    gas_constant::FT
+    molmass_dryair::FT
+end
+```
+- The struct is parameterized by `{FT}` which is a user-determined float precision
+- Only relevant parameters used in `Thermodynamics` are stored here.
+
+The constructor is as follows
+```julia
+function ThermodynamicsParameters(parameter_struct)
+
+    # Used in thermodynamics, from parameter file
+    aliases = [ ..., "gas_constant", "molmass_dryair"]
+
+    (gas_constant, molmass_dryair,) = CLIMAParameters.get_parameter_values!(
+        param_struct,
+        aliases,
+        "Thermodynamics",
+    )
+
+    # derived parameters from parameter file
+    R_d = gas_constant / molmass_dryair
+
+    return ThermodynamicsParameters{
+        CLIMAParameters.get_parametric_type(param_struct)}(...,R_d, gas_constant, molmass_dryair)
+end
+```
+
+- The constructor takes in a `parameter_struct` produced from reading the TOML file
+- We list the aliases of parameters required by `Thermodynamics.jl` 
+- We obtain parameters by calling the function `CLIMAParameters.get_parameter_values!(parameter_struct,aliases,component_name)` The `component_name` is a string used for the parameter log.
+- We then create any `derived parameters` e.g. commonly used simple functions of parameters that are treated as parameters. here we create the dry air gas constant `R_d`
+- We end by returning creating the `ThermodynamicsParameters{FT}`.
+
+
+## An example with modular components from `CloudMicrophysics.jl`
+
+### In the user-facing driver file
+
+Here we build a `CloudMicrophysics` parameter set. In this case, the user wishes to use a
+0-moment microphysics parameterization scheme.
+```julia
+import CLIMAParameters
+import Thermodynamics
+import CloudMicrophysics
+
+#load defaults
+parameter_struct = CLIMAParameters.create_parameter_struct(dict_type="alias")
+
+#build the low level parameter set
+param_therm = Thermodynamics.ThermodynamicsParameters(parameter_struct)
+param_0M = CloudMicrophysics.Microphysics_0M_Parameters(parameter_struct)
+
+#build the hierarchical parameter set
+parameter_set = CloudMicrophysics.CloudMicrophysicsParameters(
+    parameter_struct,
+    param_0M,
+    param_therm
+)
+```
+!!! note
+    The exact APIs here are subject to change
+    
+### In the source code for `CloudMicrophysics.jl`
+
+Build the different options for a Microphysics parameterizations
+```julia
+abstract type AbstractMicrophysicsParameters end
+struct NoMicrophysicsParameters <: AbstractMicrophysicsParameters end 
+struct Microphysics_0M_Parameters{FT} <: AbstractMicrophysicsParameters
+    τ_precip::FT
+    qc_0::FT
+    S_0::FT
+end
+struct Microphysics_1M_Parameters{FT} <: AbstractMicrophysicsParameters
+    ...
+end
+```
+We omit their constructors (see above). The `CloudMicrophysics` parameter set is built likewise
+
+```julia
+struct CloudMicrophysicsParameters{FT, AMPS <: AbstractMicrophysicsParameters}
+    K_therm::FT
+    ...
+    MPS::AMPS
+    TPS::ThermodynamicsParameters{FT}
+end
+
+
+function CloudMicrophysicsParameters(
+    param_set,
+    MPS::AMPS,
+    TPS::ThermodynamicsParameters{FT},
+) where {FT, AMPS <: AbstractMicrophysicsParameters}
+
+    aliases = [ "K_therm", ... ]
+
+    ( K_therm,... ) = CLIMAParameters.get_parameter_values!(
+        param_set,
+        aliases,
+        "CloudMicrophysics",
+    )
+
+    #derived parameters 
+    ...
+    
+    return CloudMicrophysicsParameters{
+        CLIMAParameters.get_parametric_type(param_set), AMPS}(
+            K_therm,
+            ...     
+            MPS,
+            TPS,
+        )
+end
+```
+
+## Calling parameters from `src`
+
+
+When building the model components, parameters are extracted by calling `param_set.name` or `param_set.alias` (currently)
+```julia
+function example_cloudmicrophysics_func(param_set::CloudMicrophysicsParameters,...)
+    K_therm = param_set.K_therm
+    ...
+end
+```
+When calling functions from dependent packages, simply pass the relevant lower_level parameter struct
+```julia
+function example_cloudmicrophysics_func(param_set::CloudMicrophysicsParameters,...)
+    thermo_output = Thermodynamics.thermo_function(param_set.TPS,...)
+    cm0_output = Microphysics_0m.microphys_function(param_set.MPS,...)
+    ...
+end
+```
+These functions should be written with this in mind (dispatching)
+```julia
+microphys_function(param_set::Microphysics_0M_parameters,...)
+   qc_0 = param_set.qc_0
+   ...
+end
+```
+
+

--- a/docs/src/toml.md
+++ b/docs/src/toml.md
@@ -1,0 +1,128 @@
+# The TOML parameter file interface
+
+The complete user interface consists of two files in `TOML` format
+1. A user-defined experiment file - in the local experiment directory
+2. A defaults file - in `src/` directory of `ClimaParameters.jl`
+
+## Parameter style-guide 
+
+A parameter is determined by its unique name. It has possible attributes
+1. `alias` 
+2. `value`  
+3. `type`
+4. `description`
+5. `prior`
+6. `transformation`
+
+!!! warn
+    Currently we only support `float` and `array{float}` types. (option-type flags and string switches are not considered CLIMAParameters.)
+    
+### Minimal parameter requirement to run in CliMA
+
+```TOML
+[molar_mass_dry_air] 
+value = 0.03
+type = "float"
+```    
+
+### A more informative parameter (e.g. found in the defaults file) 
+
+```TOML
+[molar_mass_dry_air] 
+alias = "molmass_dryair"
+value = 0.02897
+type = "float"
+description = "Molecular weight dry air (kg/mol)"
+```
+
+### A more complex parameter for calibration
+
+```TOML
+[neural_net_entrainment] 
+alias = "c_gen"
+value = [0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0]
+type = "array"
+description = "NN weights to represent the non-dimensional entrainment function"
+prior = "MvNormal(0,I)"
+```
+
+### Interaction of the files
+
+On read an experiment file, the default file is also read and any duplicate parameter attributes are overwritten 
+e.g. If the minimal example above was loaded from an experiment file, and the informative example above was in the defaults file, then the loaded parameter would look as follows: 
+``` TOML
+[molar_mass_dry_air] 
+alias = "molmass_dryair"
+value = 0.03
+type = "float"
+description = "Molecular weight dry air (kg/mol)"
+```
+Here, the `value` field has been overwritten by the experiment value
+
+## File and parameter interaction on with CliMA
+
+`ClimaParameters.jl` provides several methods to parse, merge, and log parameter information. 
+
+
+### Loading from file
+We provide the following methods to load parameters from file
+```julia
+create_parameter_struct(override_filepath, default_filepath; dict_type="alias",value_type=Float64)
+create_parameter_struct(override_filepath ; dict_type="alias",value_type=Float64) 
+create_parameter_struct(; dict_type="name",value_type=Float64) 
+```
+- The `dict_type = "name"` or `"alias"` determines the method of lookup of parameters (by `name` or by `alias` attributes).
+- The  `value_type` defines the requested precision of the returned parameters (e.g. `Float64` or `Float32`)
+
+Typical usage involves passing the local parameter file
+```julia
+import CLIMAParameters
+local_exp_file = joinpath(@__DIR__,"local_exp_parameters.toml")
+parameter_struct = CLIMAParameters.create_parameter_struct(local_exp_file) 
+```
+If no file is passed it will use only the defaults from `ClimaParameters.jl` (causing errors if required parameters are not within this list).
+
+!!! note
+    Currently we search by the `alias` field (`dict_type="alias"` by default), so all parameters need an `alias` field, if in doubt, set alias and name to match the current code name convention
+
+The parameter struct is then used to build the codebase (see relevant Docs page)
+
+### Logging parameters
+
+Once the CliMA components are built, it is important to log the parameters. We provide the following methodd
+```julia
+log_parameter_information(parameter_struct, filepath; warn_else_error="warn")
+```
+
+Typical usage will be after building components and before running
+```julia
+import Thermodynamics
+therm_params = Thermodynamics.ThermodynamicsParameters(parameter_struct)
+#... build(thermodynamics model,therm_params)
+
+log_file = joinpath(@__DIR__,"parameter_log.toml")
+CLIMAParameters.log_parameter_information(parameter_struct,log_file)
+
+# ... run(thermodynamics_model)
+```
+
+This function performs two tasks
+1. It writes a parameter log file to `log_file`.
+2. It performs parameter sanity checks.
+
+Continuing our previous example, imagine `molar_mass_dry_air` was extracted in `ThermodynamicsParameters`. Then the log file will contain:
+``` TOML
+[molar_mass_dry_air] 
+alias = "molmass_dryair"
+value = 0.03
+type = "float"
+description = "Molecular weight dry air (kg/mol)"
+used_in = ["Thermodynamics"]
+```
+The additional attribute `used_in` displays every CliMA component that used this parameter. 
+
+!!! note
+    Log files are written in TOML format, and can be read back into the model
+
+!!! warn
+    It is assumed that all parameters in the local experiment file should be used, if not a warning is displayed when calling `log_parameter_information`. this is upgraded to an error exception by changing `warn_else_error`

--- a/src/CLIMAParameters.jl
+++ b/src/CLIMAParameters.jl
@@ -4,6 +4,7 @@ export AbstractParameterSet
 export AbstractEarthParameterSet
 
 include("file_parsing.jl")
+include("file_parsing_uq.jl")
 include("types.jl")
 include("UniversalConstants.jl")
 

--- a/src/file_parsing.jl
+++ b/src/file_parsing.jl
@@ -125,7 +125,7 @@ end
 
 
 
-log_component!(param_set::ParamDict{FT},names,component) = log_component!(param_set.data,names,component,param_set.dict_type)
+log_component!(param_set::ParamDict{FT},names,component) where {FT} = log_component!(param_set.data,names,component,param_set.dict_type)
 
 function log_component!(data::Dict,names,component,dict_type)
     if dict_type == "alias"
@@ -156,7 +156,7 @@ function log_component!(data::Dict,names,component,dict_type)
     end
 end
 
-get_values(param_set::ParamDict{FT}, names) = get_values(param_set.data, names, param_set.dict_type)
+get_values(param_set::ParamDict{FT}, names) where {FT} = get_values(param_set.data, names, param_set.dict_type)
 
 function get_values(data::Dict, names, dict_type)
 
@@ -177,7 +177,7 @@ function get_values(data::Dict, names, dict_type)
     return ret_values
 end
 
-function get_parameter_values!(param_set::ParamDict{FT}, names, component; log_component=true)
+function get_parameter_values!(param_set::ParamDict{FT}, names, component; log_component=true) where {FT}
     names_vec = (typeof(names) <: AbstractVector) ? names : [names]
     
     if log_component
@@ -188,18 +188,18 @@ function get_parameter_values!(param_set::ParamDict{FT}, names, component; log_c
 end
 
 #as log_component is false, the get_parameter_values! does not change param_set
-get_parameter_values(param_set::ParamDict{FT}, names) = get_parameter_values!(param_set, names, nothing, log_component=false)
+get_parameter_values(param_set::ParamDict{FT}, names) where {FT} = get_parameter_values!(param_set, names, nothing, log_component=false)
 
 
 # write a parameter log file to given file. Unfortunately it is unordered thanks to TOML.jl
 # can't read in an ordered dict
-function write_log_file(param_set::ParamDict{FT}, filepath)
+function write_log_file(param_set::ParamDict{FT}, filepath) where {FT}
     open(filepath, "w") do io
         TOML.print(io, param_set.data)
     end
 end
 
-function merge_override_default_values(override_param_struct::ParamDict{FT},default_param_struct::ParamDict{FT})
+function merge_override_default_values(override_param_struct::ParamDict{FT},default_param_struct::ParamDict{FT}) where {FT}
     merged_struct = deepcopy(default_param_struct)
     for (key, val) in override_param_struct.data
         if ~(key in keys(merged_struct.data))
@@ -215,11 +215,9 @@ end
 
 
 function create_parameter_struct(path_to_override, path_to_default; dict_type="alias")
-    #for now we fix the value type
-    value_type = Float64
     #if there isn't  an override file take defaults
     if isnothing(path_to_override)
-        return ParamDict{Float64}(parse_toml_file(path_to_default), dict_type, value_type)
+        return ParamDict{Float64}(parse_toml_file(path_to_default), dict_type)
     else
         try 
             override_param_struct = ParamDict{Float64}(parse_toml_file(path_to_override), dict_type)

--- a/src/file_parsing.jl
+++ b/src/file_parsing.jl
@@ -4,83 +4,6 @@ function parse_toml_file(filepath)
     return TOML.parsefile(filepath)
 end
 
-#=
-function create_alias_value_dict(full_parameter_dict)
-    alias_value_dict = Dict{String, Float64}()
-    for (key, val) in full_parameter_dict
-        # In the future - we will use the full names,
-        # param_dict[key] = val["value"]
-        
-        # for now we use the aliases
-        alias_value_dict[val["alias"]] = val["value"]
-    end
-    return alias_value_dict
-end
-
-function create_name_value_dict(full_parameter_dict)
-    name_value_dict = Dict{String, Float64}()
-    for (key, val) in full_parameter_dict
-        # In the future - we will use the full names,
-        name_value_dict[key] = val["value"]
-    end
-    return name_value_dict
-end
-
-function merge_override_default_values(override_param_dict,default_param_dict)
-    merged_dict = default_param_dict
-    for (key, val) in override_param_dict
-        merged_dict[key] = val
-    end
-    return merged_dict
-end
-
-function create_param_dict(full_parameter_dict, dict_type)
-    if dict_type == "alias"
-        return create_alias_value_dict(full_parameter_dict)
-    elseif dict_type == "name"
-        return create_name_value_dict(full_parameter_dict)
-    else
-        throw(ArgumentError("Unknown dict_type, choose from \"alias\" or \"name\""))
-    end
-end
-
-function create_parameter_dict(path_to_override, path_to_default; dict_type="alias")
-    #if there isn't  an override file take defaults
-    if isnothing(path_to_override)
-        return create_param_dict(parse_toml_file(path_to_default), dict_type)
-    else
-        try 
-            override_param_dict = create_param_dict(parse_toml_file(path_to_override), dict_type)
-            default_param_dict = create_param_dict(parse_toml_file(path_to_default), dict_type)
-        
-            #overrides the defaults where they clash
-            return merge_override_default_values(override_param_dict, default_param_dict)
-        catch
-            @warn("Error in building from parameter file: ", path_to_override,"instead, created using defaults from CLIMAParameters...")
-            return create_param_dict(parse_toml_file(path_to_default), dict_type)
-        end
-    end
-        
-end
-
-function create_parameter_dict(path_to_override; dict_type="alias")
-    #pathof finds the CLIMAParameters.jl/src/ClimaParameters.jl location
-    path_to_default = joinpath(splitpath(pathof(CLIMAParameters))[1:end-1]...,"parameters.toml")
-    return create_parameter_dict(
-        path_to_override,
-        path_to_default,
-        dict_type=dict_type
-    )
-end
-
-function create_parameter_dict(; dict_type="alias")
-    return create_parameter_dict(
-        nothing,
-        dict_type=dict_type
-    )
-end
-=#
-# Alternatively do it with a wrapper struct. 
 struct ParamDict{FT}
     data::Dict
     dict_type::String
@@ -128,14 +51,15 @@ end
 log_component!(param_set::ParamDict{FT},names,component) where {FT} = log_component!(param_set.data,names,component,param_set.dict_type)
 
 function log_component!(data::Dict,names,component,dict_type)
+    component_key = "used_in"
     if dict_type == "alias"
         for name in names
             for (key,val) in data
                 if name == val["alias"]
-                    if ["used_in_components"] in keys(data[key])
-                        append!(data[key]["used_in_components"],[String(Symbol(component))])
+                    if component_key in keys(data[key])
+                        data[key][component_key] = unique([data[key][component_key]...,String(Symbol(component))])
                     else
-                        data[key]["used_in_components"] = [String(Symbol(component))]
+                        data[key][component_key] = [String(Symbol(component))]
                     end
                 end
             end
@@ -144,10 +68,10 @@ function log_component!(data::Dict,names,component,dict_type)
          for name in names
             for (key,val) in data
                 if name == key
-                    if ["used_in_components"] in keys(data[key])
-                        append!(data[key]["used_in_components"],[String(Symbol(component))])
+                    if component_key in keys(data[key])
+                        data[key][component_key] = unique([data[key][component_key]...,String(Symbol(component))])
                     else
-                        data[key]["used_in_components"] = [String(Symbol(component))]
+                        data[key][component_key] = [String(Symbol(component))]
                     end
                 end
             end

--- a/src/file_parsing.jl
+++ b/src/file_parsing.jl
@@ -80,22 +80,33 @@ function log_component!(data::Dict,names,component,dict_type)
     end
 end
 
-get_values(param_set::ParamDict{FT}, names) where {FT} = get_values(param_set.data, names, param_set.dict_type, get_parametric_type(param_set))
+get_values(param_set::ParamDict{FT}, names) where {FT} =
+    get_values(param_set.data, names, param_set.dict_type, get_parametric_type(param_set))
 
 function get_values(data::Dict, names, dict_type, ret_values_type)
     
-    ret_values = ret_values_type[]
+    ret_values = []
     if dict_type == "alias"
         for name in names
             for (key,val) in data
                 if name == val["alias"]
-                    append!(ret_values,val["value"])
+                    param_value = val["value"]
+                    if eltype(param_value) != ret_values_type
+                        push!(ret_values, map(ret_values_type, param_value))
+                    else
+                        push!(ret_values, param_value)
+                    end
                 end
             end
         end
     elseif dict_type == "name"
         for name in names
-            append!(ret_values,val["value"])
+            param_value = data[name]["value"]
+            if eltype(param_value) != ret_values_type
+                push!(ret_values, map(ret_values_type, param_value))
+            else
+                push!(ret_values, param_value)
+            end
         end
     end
     return ret_values
@@ -113,7 +124,6 @@ end
 
 #as log_component is false, the get_parameter_values! does not change param_set
 get_parameter_values(param_set::ParamDict{FT}, names) where {FT} = get_parameter_values!(param_set, names, nothing, log_component=false)
-
 
 # write a parameter log file to given file. Unfortunately it is unordered thanks to TOML.jl
 # can't read in an ordered dict

--- a/src/file_parsing.jl
+++ b/src/file_parsing.jl
@@ -1,4 +1,5 @@
 using TOML
+using DocStringExtensions
 
 """
     ParamDict{FT}

--- a/src/file_parsing.jl
+++ b/src/file_parsing.jl
@@ -138,20 +138,20 @@ function merge_override_default_values(override_param_struct::ParamDict{FT},defa
 end
 
 
-function create_parameter_struct(path_to_override, path_to_default; dict_type="alias")
+function create_parameter_struct(path_to_override, path_to_default; dict_type="alias", value_type=Float64)
     #if there isn't  an override file take defaults
     if isnothing(path_to_override)
-        return ParamDict{Float64}(parse_toml_file(path_to_default), dict_type)
+        return ParamDict{value_type}(parse_toml_file(path_to_default), dict_type)
     else
         try 
-            override_param_struct = ParamDict{Float64}(parse_toml_file(path_to_override), dict_type)
-            default_param_struct = ParamDict{Float64}(parse_toml_file(path_to_default), dict_type)
+            override_param_struct = ParamDict{value_type}(parse_toml_file(path_to_override), dict_type)
+            default_param_struct = ParamDict{value_type}(parse_toml_file(path_to_default), dict_type)
         
             #overrides the defaults where they clash
             return merge_override_default_values(override_param_struct, default_param_struct)
         catch
             @warn("Error in building from parameter file: ", path_to_override,"instead, created using defaults from CLIMAParameters...")
-            return ParamDict{Float64}(parse_toml_file(path_to_default), dict_type)
+            return ParamDict{value_type}(parse_toml_file(path_to_default), dict_type)
         end
     end
         
@@ -159,20 +159,22 @@ end
 
 
 
-function create_parameter_struct(path_to_override; dict_type="alias")
+function create_parameter_struct(path_to_override; dict_type="alias", value_type=Float64)
     #pathof finds the CLIMAParameters.jl/src/ClimaParameters.jl location
     path_to_default = joinpath(splitpath(pathof(CLIMAParameters))[1:end-1]...,"parameters.toml")
     return create_parameter_struct(
         path_to_override,
         path_to_default,
-        dict_type=dict_type
+        dict_type=dict_type,
+        value_type=value_type,
     )
 end
 
-function create_parameter_struct(; dict_type="alias")
+function create_parameter_struct(; dict_type="alias", value_type=Float64)
     return create_parameter_struct(
         nothing,
-        dict_type=dict_type
+        dict_type=dict_type,
+        value_type=value_type,
     )
 end
 

--- a/src/file_parsing.jl
+++ b/src/file_parsing.jl
@@ -81,10 +81,13 @@ function create_parameter_dict(; dict_type="alias")
 end
 =#
 # Alternatively do it with a wrapper struct. 
-struct ParamDict
+struct ParamDict{FT}
     data::Dict
     dict_type::String
 end
+
+# to get the "float" or whatever back
+get_parametric_type(::ParamDict{FT}) where {FT} = FT
 
 function iterate_alias(d::Dict)
     it = iterate(d)
@@ -104,14 +107,15 @@ function iterate_alias(d::Dict, state)
     end
 end
 
-function Base.iterate(pd::ParamDict)
+function Base.iterate(pd::ParamDict{FT}) where {FT}
     if pd.dict_type == "name"
         return Base.iterate(pd.data)
     else
         return iterate_alias(pd.data)
     end
 end
-function Base.iterate(pd::ParamDict,state)
+
+function Base.iterate(pd::ParamDict{FT},state) where {FT}
     if pd.dict_type == "name"
         return Base.iterate(pd.data,state)
     else
@@ -121,7 +125,7 @@ end
 
 
 
-log_component!(param_set::ParamDict,names,component) = log_component!(param_set.data,names,component,param_set.dict_type)
+log_component!(param_set::ParamDict{FT},names,component) = log_component!(param_set.data,names,component,param_set.dict_type)
 
 function log_component!(data::Dict,names,component,dict_type)
     if dict_type == "alias"
@@ -152,7 +156,7 @@ function log_component!(data::Dict,names,component,dict_type)
     end
 end
 
-get_values(param_set::ParamDict, names) = get_values(param_set.data, names, param_set.dict_type)
+get_values(param_set::ParamDict{FT}, names) = get_values(param_set.data, names, param_set.dict_type)
 
 function get_values(data::Dict, names, dict_type)
 
@@ -173,7 +177,7 @@ function get_values(data::Dict, names, dict_type)
     return ret_values
 end
 
-function get_parameter_values!(param_set::ParamDict, names, component; log_component=true)
+function get_parameter_values!(param_set::ParamDict{FT}, names, component; log_component=true)
     names_vec = (typeof(names) <: AbstractVector) ? names : [names]
     
     if log_component
@@ -184,18 +188,18 @@ function get_parameter_values!(param_set::ParamDict, names, component; log_compo
 end
 
 #as log_component is false, the get_parameter_values! does not change param_set
-get_parameter_values(param_set::ParamDict, names) = get_parameter_values!(param_set, names, nothing, log_component=false)
+get_parameter_values(param_set::ParamDict{FT}, names) = get_parameter_values!(param_set, names, nothing, log_component=false)
 
 
 # write a parameter log file to given file. Unfortunately it is unordered thanks to TOML.jl
 # can't read in an ordered dict
-function write_log_file(param_set::ParamDict, filepath)
+function write_log_file(param_set::ParamDict{FT}, filepath)
     open(filepath, "w") do io
         TOML.print(io, param_set.data)
     end
 end
 
-function merge_override_default_values(override_param_struct::ParamDict,default_param_struct::ParamDict)
+function merge_override_default_values(override_param_struct::ParamDict{FT},default_param_struct::ParamDict{FT})
     merged_struct = deepcopy(default_param_struct)
     for (key, val) in override_param_struct.data
         if ~(key in keys(merged_struct.data))
@@ -211,19 +215,21 @@ end
 
 
 function create_parameter_struct(path_to_override, path_to_default; dict_type="alias")
+    #for now we fix the value type
+    value_type = Float64
     #if there isn't  an override file take defaults
     if isnothing(path_to_override)
-        return ParamDict(parse_toml_file(path_to_default), dict_type)
+        return ParamDict{Float64}(parse_toml_file(path_to_default), dict_type, value_type)
     else
         try 
-            override_param_struct = ParamDict(parse_toml_file(path_to_override), dict_type)
-            default_param_struct = ParamDict(parse_toml_file(path_to_default), dict_type)
+            override_param_struct = ParamDict{Float64}(parse_toml_file(path_to_override), dict_type)
+            default_param_struct = ParamDict{Float64}(parse_toml_file(path_to_default), dict_type)
         
             #overrides the defaults where they clash
             return merge_override_default_values(override_param_struct, default_param_struct)
         catch
             @warn("Error in building from parameter file: ", path_to_override,"instead, created using defaults from CLIMAParameters...")
-            return ParamDict(parse_toml_file(path_to_default), dict_type)
+            return ParamDict{Float64}(parse_toml_file(path_to_default), dict_type)
         end
     end
         

--- a/src/file_parsing.jl
+++ b/src/file_parsing.jl
@@ -4,9 +4,7 @@ function parse_toml_file(filepath)
     return TOML.parsefile(filepath)
 end
 
-
-
-
+#=
 function create_alias_value_dict(full_parameter_dict)
     alias_value_dict = Dict{String, Float64}()
     for (key, val) in full_parameter_dict
@@ -81,3 +79,172 @@ function create_parameter_dict(; dict_type="alias")
         dict_type=dict_type
     )
 end
+=#
+# Alternatively do it with a wrapper struct. 
+struct ParamDict
+    data::Dict
+    dict_type::String
+end
+
+function iterate_alias(d::Dict)
+    it = iterate(d)
+    if it !== nothing
+        return (Pair(it[1].second["alias"],it[1].second),it[2])
+    else
+        return nothing
+    end
+end
+
+function iterate_alias(d::Dict, state)
+    it = iterate(d,state)
+    if it !== nothing
+        return (Pair(it[1].second["alias"],it[1].second),it[2])
+    else
+        return nothing
+    end
+end
+
+function Base.iterate(pd::ParamDict)
+    if pd.dict_type == "name"
+        return Base.iterate(pd.data)
+    else
+        return iterate_alias(pd.data)
+    end
+end
+function Base.iterate(pd::ParamDict,state)
+    if pd.dict_type == "name"
+        return Base.iterate(pd.data,state)
+    else
+        return iterate_alias(pd.data,state)
+    end
+end
+
+
+
+log_component!(param_set::ParamDict,names,component) = log_component!(param_set.data,names,component,param_set.dict_type)
+
+function log_component!(data::Dict,names,component,dict_type)
+    if dict_type == "alias"
+        for name in names
+            for (key,val) in data
+                if name == val["alias"]
+                    if ["used_in_components"] in keys(data[key])
+                        append!(data[key]["used_in_components"],[String(Symbol(component))])
+                    else
+                        data[key]["used_in_components"] = [String(Symbol(component))]
+                    end
+                end
+            end
+        end
+    elseif dict_type == "name"
+         for name in names
+            for (key,val) in data
+                if name == key
+                    if ["used_in_components"] in keys(data[key])
+                        append!(data[key]["used_in_components"],[String(Symbol(component))])
+                    else
+                        data[key]["used_in_components"] = [String(Symbol(component))]
+                    end
+                end
+            end
+         end
+        
+    end
+end
+
+get_values(param_set::ParamDict, names) = get_values(param_set.data, names, param_set.dict_type)
+
+function get_values(data::Dict, names, dict_type)
+
+    ret_values = []
+    if dict_type == "alias"
+        for name in names
+            for (key,val) in data
+                if name == val["alias"]
+                    append!(ret_values,val["value"])
+                end
+            end
+        end
+    elseif dict_type == "name"
+        for name in names
+            append!(ret_values,val["value"])
+        end
+    end
+    return ret_values
+end
+
+function get_parameter_values!(param_set::ParamDict, names, component; log_component=true)
+    names_vec = (typeof(names) <: AbstractVector) ? names : [names]
+    
+    if log_component
+        log_component!(param_set,names_vec,component)
+    end
+    
+    return (typeof(names) <: AbstractVector) ? get_values(param_set,names_vec) : get_values(param_set,names_vec)[1]
+end
+
+#as log_component is false, the get_parameter_values! does not change param_set
+get_parameter_values(param_set::ParamDict, names) = get_parameter_values!(param_set, names, nothing, log_component=false)
+
+
+# write a parameter log file to given file. Unfortunately it is unordered thanks to TOML.jl
+# can't read in an ordered dict
+function write_log_file(param_set::ParamDict, filepath)
+    open(filepath, "w") do io
+        TOML.print(io, param_set.data)
+    end
+end
+
+function merge_override_default_values(override_param_struct::ParamDict,default_param_struct::ParamDict)
+    merged_struct = deepcopy(default_param_struct)
+    for (key, val) in override_param_struct.data
+        if ~(key in keys(merged_struct.data))
+            merged_struct.data[key] = val
+        else
+            for (kkey,vval) in val # as val is a Dict too
+                merged_struct.data[key][kkey] = vval
+            end
+        end
+    end
+    return merged_struct
+end
+
+
+function create_parameter_struct(path_to_override, path_to_default; dict_type="alias")
+    #if there isn't  an override file take defaults
+    if isnothing(path_to_override)
+        return ParamDict(parse_toml_file(path_to_default), dict_type)
+    else
+        try 
+            override_param_struct = ParamDict(parse_toml_file(path_to_override), dict_type)
+            default_param_struct = ParamDict(parse_toml_file(path_to_default), dict_type)
+        
+            #overrides the defaults where they clash
+            return merge_override_default_values(override_param_struct, default_param_struct)
+        catch
+            @warn("Error in building from parameter file: ", path_to_override,"instead, created using defaults from CLIMAParameters...")
+            return ParamDict(parse_toml_file(path_to_default), dict_type)
+        end
+    end
+        
+end
+
+
+
+function create_parameter_struct(path_to_override; dict_type="alias")
+    #pathof finds the CLIMAParameters.jl/src/ClimaParameters.jl location
+    path_to_default = joinpath(splitpath(pathof(CLIMAParameters))[1:end-1]...,"parameters.toml")
+    return create_parameter_struct(
+        path_to_override,
+        path_to_default,
+        dict_type=dict_type
+    )
+end
+
+function create_parameter_struct(; dict_type="alias")
+    return create_parameter_struct(
+        nothing,
+        dict_type=dict_type
+    )
+end
+

--- a/src/file_parsing.jl
+++ b/src/file_parsing.jl
@@ -80,11 +80,11 @@ function log_component!(data::Dict,names,component,dict_type)
     end
 end
 
-get_values(param_set::ParamDict{FT}, names) where {FT} = get_values(param_set.data, names, param_set.dict_type)
+get_values(param_set::ParamDict{FT}, names) where {FT} = get_values(param_set.data, names, param_set.dict_type, get_parametric_type(param_set))
 
-function get_values(data::Dict, names, dict_type)
-
-    ret_values = []
+function get_values(data::Dict, names, dict_type, ret_values_type)
+    
+    ret_values = ret_values_type[]
     if dict_type == "alias"
         for name in names
             for (key,val) in data

--- a/src/file_parsing.jl
+++ b/src/file_parsing.jl
@@ -149,8 +149,15 @@ end
 # write a parameter log file to given file. Unfortunately it is unordered thanks to TOML.jl
 # can't read in an ordered dict
 function write_log_file(param_set::ParamDict{FT}, filepath) where {FT}
+    component_key = "used_in"
+    used_parameters = Dict()
+    for (key,val) in param_set.data
+        if ~(component_key in keys(val))
+            used_parameters[key] = val
+        end
+    end
     open(filepath, "w") do io
-        TOML.print(io, param_set.data)
+        TOML.print(io, used_parameters)
     end
 end
 

--- a/src/file_parsing.jl
+++ b/src/file_parsing.jl
@@ -1,6 +1,21 @@
 using TOML
 using DocStringExtensions
 
+export ParamDict
+export parse_toml_file,
+    get_parametric_type,
+    iterate_alias,
+    log_component!,
+    get_values,
+    get_parameter_values!,
+    get_parameter_values,
+    check_override_parameter_usage,
+    write_log_file,
+    log_parameter_information,
+    merge_override_default_values,
+    create_parameter_struct
+        
+    
 """
     ParamDict{FT}
 
@@ -176,7 +191,6 @@ end
 
 Gets the parameter values only.
 """
-#as log_component is false, the get_parameter_values! does not change param_set
 get_parameter_values(param_set::ParamDict{FT}, names) where {FT} = get_parameter_values!(param_set, names, nothing, log_component=false)
 
 """

--- a/src/file_parsing.jl
+++ b/src/file_parsing.jl
@@ -297,6 +297,8 @@ end
 
 
 """
+    create_parameter_struct(path_to_override; dict_type="alias", value_type=Float64)
+
 a single filepath is assumed to be the override file, defaults are obtained from the CLIMAParameters defaults list.
 """
 function create_parameter_struct(path_to_override; dict_type="alias", value_type=Float64)
@@ -311,6 +313,8 @@ function create_parameter_struct(path_to_override; dict_type="alias", value_type
 end
 
 """
+    create_parameter_struct(; dict_type="alias", value_type=Float64)
+
 when no filepath is provided, all parameters are created from CLIMAParameters defaults list.
 """
 function create_parameter_struct(; dict_type="alias", value_type=Float64)

--- a/src/file_parsing_uq.jl
+++ b/src/file_parsing_uq.jl
@@ -1,0 +1,689 @@
+using TOML
+using Distributions
+using EnsembleKalmanProcesses.ParameterDistributions
+
+
+# "Public" functions (i.e., functions intended to be called by user):
+#    - read_parameters
+#    - get_UQ_parameters
+#    - get_parameter_distribution
+#    - save_parameter_ensemble
+
+"""
+read_parameters(path_to_toml_file)
+
+Read parameters from toml file
+
+Args:
+`path_to_toml_file` - path of the toml file containing the parameters to be
+                      read.
+                      See `CLIMAParameters/test/uq_test_parameters.toml` for
+                      an example toml file that illustrates the expected
+                      format of the parameter information.
+
+Returns a nested dictionary whose keys are the parameter names (= headers of
+the toml tables) and whose values are dictionaries containing the corresponding
+parameter information (e.g., "prior", "constraint", "value", etc.)
+"""
+function read_parameters(path_to_toml_file::AbstractString)
+    param_dict = TOML.parsefile(path_to_toml_file)
+    return param_dict
+end
+
+
+"""
+get_parameter_distribution(param_dict, names)
+
+Construct a `ParameterDistribution` from the prior distribution(s) and
+constraint(s) given in `param_dict`
+
+Args:
+`param_dict` - nested dictionary that has parameter names as keys and the
+               corresponding dictionary of parameter information as values
+`names` - list of parameter names or single parameter name
+
+Returns a `ParameterDistribution`
+"""
+function get_parameter_distribution(param_dict::Dict, names::Union{AbstractString, Array{String, 1}})
+
+    names_vec = (typeof(names) <: AbstractVector) ? names : [names]
+    n_names = length(names_vec)
+    constraint = []
+    prior = []
+    param_names = []
+
+    for name in names_vec
+        # Constructing a parameter distribution requires prior distribution(s),
+        # constraint(s), and name(s).
+        d = construct_prior(param_dict[name])
+        is_array = typeof(d) <: AbstractArray ? true : false
+        ((is_array) && (n_names > 1)) ? push!(prior, d...) : push!(prior, d)
+        c = construct_constraint(param_dict[name], is_array)
+        ((is_array) && (n_names > 1)) ? push!(constraint, c...) : push!(constraint, c)
+        # Names can usually be taken directly from the header of the
+        # corresponding parameter table in the toml file. However, names
+        # have to be generated when the construction of a prameter distribution
+        # involves broadcasting of priors / constraints.
+        if is_array
+            # A broadcast parameter
+            push!(param_names, broadcast_name(name, length(d))...)
+        else
+            # Not a broadcast parameter
+            push!(param_names, name)
+        end
+    end
+
+    if length(vcat(param_names...)) != length(names_vec)
+        # The ParameterDistribution contains at least one broadcast parameter 
+        if typeof(names) <: AbstractString
+            # The broadcast parameter is the only building block of the
+            # parameter distribution
+            return ParameterDistribution(
+                prior[1],
+                constraint[1],
+                identity.(param_names))
+        else
+            # The ParameterDistribution consists of a broadcast parameter and at
+            # least one additional parameter
+            return ParameterDistribution(
+                identity.(prior),
+                identity.(constraint),
+                identity.(param_names))
+        end
+
+    elseif length(param_names) > 1
+        # The ParameterDistribution consists of multiple parameters
+        return ParameterDistribution(
+            identity.(prior),
+            identity.(constraint),
+            identity.(param_names))
+    else
+        # The ParameterDistribution consists of a single (non-broadcast)
+        # parameter
+        return ParameterDistribution(
+            prior[1],
+            constraint[1],
+            param_names[1])
+    end
+end
+
+
+"""
+construct_constraint(param_info, is_array)
+
+Extracts information on type and arguments of each constraint and uses that
+information to construct an actual `Constraint`.
+
+Args:
+`param_info` - dictionary with (at least) a key "constraint", whose value is
+               the parameter's constraint(s) (as parsed from TOML file)
+
+`is_array` - true if this constraint is associated with an array of
+             distributions (which typically results from parsing expressions
+             of type "repeat([distribution], n_repetitions)"), false otherwise.
+             Matters for the `ParameterDistribution` constructor, which
+             requires constraints to be given as a list of 1-element lists if
+             `is_array` is true (e.g., [[no_constraint()], [no_constraint()]])
+
+Returns a single `Constraint` if `param_info` only contains one constraint,
+otherwise it returns an array of `Constraint`s
+"""
+function construct_constraint(param_info::Dict, is_array::Bool)
+
+    @assert(haskey(param_info, "constraint"))
+    c = Meta.parse(param_info["constraint"])
+
+    if c.args[1] == Symbol("repeat")
+        # There are multiple constraints described by an expression of the
+        # form "repeat([constraint], n_repetitions)"
+        return broadcast_constraint(c, is_array)
+
+    elseif c.head == Symbol("vect")
+        # There are multiple parameters, hence multiple constraints
+        return get_multidim_constraint(c)
+
+    else
+        # There is only a single 1-dim parameter, hence a single constraint
+        return get_onedim_constraint(c)
+    end
+end
+
+
+"""
+construct_prior(param_info)
+
+Extracts information on type and arguments of the prior distribution and use
+that information to construct an actual `Distribution`
+
+Args:
+`param_info` - dictionary with (at least) a key "prior", whose value is the
+               parameter's distribution(s) (as parsed from TOML file)
+
+Returns a single or array of ParameterDistributionType derived objects
+"""
+function construct_prior(param_info::Dict)
+
+    @assert(haskey(param_info, "prior"))
+    d = Meta.parse(param_info["prior"])
+
+    if d.args[1] == Symbol("repeat")
+        # There are multiple distributions described by an expression of the
+        # form "repeat([distribution], n_repetitions)"
+        return broadcast_prior(d)
+
+    elseif d.head == Symbol("vect")
+        # Multiple distributions
+        return get_multidim_prior(d)
+
+    else
+        # Single distribution
+        return get_onedim_prior(d)
+    end
+end
+
+
+"""
+broadcast_name(base_name, n_repetitions)
+
+Generates numbered parameter names <base_name>_(<i>); i in 1, ..., n_repetitions
+Example:
+    broadcast_name("my_param", 3)
+    returns ["my_param_(1)", "my_param_(2)", "my_param_(3)"]
+
+Args:
+`base_name` - base name to which numbers will be added
+`n_repetitions` - number of derived parameter names to generate from `base_name`
+
+Returns an array of length n_repetitions
+"""
+function broadcast_name(base_name::AbstractString, n_repetitions::Int)
+
+    param_name(j) = base_name * "_(" * lpad(j,ndigits(n_repetitions), "0") * ")"
+
+    return [param_name(j) for j in 1:n_repetitions]
+end
+
+
+"""
+broadcast_constraint(expr, is_array)
+
+Constructs an array of constraints from an expression of the sort
+    "repeat([no_constraint], 10)",
+    "repeat([[bounded_below(0.3)]], 100),
+    etc.
+
+Args:
+`expr`  - expression with expr.args[1] == Symbol("repeat")
+`is_array` - true if this constraint is associated with an array of
+             distributions (which typically results from parsing expressions
+             of type "repeat([distribution], n_repetitions)"), false otherwise.
+
+Returns an array of constraints
+"""
+function broadcast_constraint(c::Expr, is_array::Bool)
+
+    @assert(c.args[1] == Symbol("repeat"))
+    n_repetitions  = c.args[3]
+    if is_array
+        constraint = get_onedim_constraint(c.args[2].args[1].args[1])
+        return repeat([[constraint]], n_repetitions)
+    else
+        constraint = get_onedim_constraint(c.args[2].args[1])
+        return repeat([constraint], n_repetitions)
+    end
+end
+
+
+"""
+get_multidim_constraints(c)
+
+Parses multidimensional constraints
+
+Args:
+`c`  - expression containing the constraint information
+
+Returns an array of `Constraint`s
+"""
+function get_multidim_constraint(c::Expr)
+
+    constraints = []
+    constraint_groups = c.args
+    n_constraint_groups = length(c.args)
+
+    for i in 1:n_constraint_groups
+
+        if constraint_groups[i].head == Symbol("vect")
+            # This is a multidimensional parameter
+            n_param_constraints = length(constraint_groups[i].args)
+            param_constraints = []
+
+            for j in 1:n_param_constraints
+                push!(
+                    param_constraints,
+                    getfield(Main, constraint_groups[i].args[j].args[1])(
+                        constraint_groups[i].args[j].args[2:end]...)
+                )
+            end
+
+            push!(constraints, param_constraints)
+
+        else
+            # This is a single parameter
+            push!(constraints,
+                  getfield(Main, constraint_groups[i].args[1])(
+                      constraint_groups[i].args[2:end]...))
+        end
+    end
+
+    return [constraints[i] for i in 1:length(constraints)]
+end
+
+
+"""
+get_onedim_constraint(c)
+
+Parses a one-dimensional constraint
+
+Args:
+`c`  - expression containing the constraint information
+
+Returns a `Constraint`
+"""
+function get_onedim_constraint(c::Expr)
+
+    return getfield(Main, c.args[1])(c.args[2:end]...)
+end
+
+
+"""
+broadcast_prior(d)
+
+Constructs an array of constraints or distributions from an expression of
+the sort
+    "repeat([Parameterized(Gamma(2.0, 3.0))], 50)",
+    "repeat([Samples([1.0 1.5 2.0; 0.7 1.2 1.8])], 100)",
+    etc.
+
+Args:
+`d`  - expression with expr.args[1] == Symbol("repeat")
+
+Returns an array of prior distributions
+"""
+function broadcast_prior(d::Expr)
+
+    @assert(d.args[1] == Symbol("repeat"))
+    prior = get_onedim_prior(d.args[2].args[1])
+    n_repetitions = d.args[3]
+
+    return repeat([prior], n_repetitions)
+end
+
+
+"""
+get_multidim_prior(d)
+
+Parses multidimensional prior distributions
+
+Args:
+`d`  - expression containing the distribution information
+
+Returns an array of prior distributions (`Parameterized` or `Samples`)
+"""
+function get_multidim_prior(d::Expr)
+
+    n_distributions = length(d.args)
+    distributions = Array{ParameterDistributionType}(undef, n_distributions)
+
+    for i in range(1, stop=n_distributions)
+        dist_type_symb = d.args[i].args[1]
+        dist_type = getfield(Main, dist_type_symb)
+
+        if dist_type_symb == Symbol("Parameterized")
+            dist = getfield(Main, d.args[i].args[2].args[1])
+            dist_args = d.args[i].args[2].args[2:end]
+            distributions[i] = dist_type(dist(dist_args...))
+
+        elseif dist_type_symb == Symbol("Samples")
+            dist_args = construct_2d_array(d.args[i].args[2])
+            distributions[i] = dist_type(dist_args)
+
+        else
+            throw(error("Unknown distribution type ", dist_type))
+        end
+    end
+
+    return distributions
+end
+
+
+"""
+get_onedim_prior(d)
+
+Parses a one-dimensional prior distributions
+
+Args:
+`d`  - expression containing the distribution information
+
+Returns a single prior distributions (`Parameterized` or `Samples`)
+"""
+function get_onedim_prior(d::Expr)
+
+    dist_type_symb = d.args[1]
+    dist_type = getfield(Main, dist_type_symb)
+
+    if dist_type_symb == Symbol("Parameterized")
+        dist = getfield(Main, d.args[2].args[1])
+        dist_args = d.args[2].args[2:end]
+
+        return dist_type(dist(dist_args...))
+
+    elseif dist_type_symb == Symbol("Samples")
+        dist_args = construct_2d_array(d.args[2])
+
+        return dist_type(dist_args)
+
+    else
+        throw(error("Unknown distribution type ", dist_type))
+    end
+end
+
+
+"""
+construct_2d_array(arr)
+
+Reconstructs 2d array of samples
+
+Args:
+`arr`  - expression (has type `Expr`) with head `vcat`.
+
+Returns a 2d array of samples constructed from the arguments of `expr`
+"""
+function construct_2d_array(arr::Expr)
+
+    @assert(arr.head == Symbol("vcat"))
+    n_rows = length(arr.args)
+    arr_of_rows = [arr.args[i].args for i in 1:n_rows]
+
+    return Float64.(vcat(arr_of_rows'...))
+end
+
+
+"""
+save_parameter_ensemble(
+    param_array,
+    param_distribution,
+    default_param_data,
+    save_path,
+    save_file,
+    iter=nothing)
+
+Saves the parameters in the given `param_array` to TOML files. The intended
+use is for saving the ensemble of parameters after each update of an
+ensemble Kalman process.
+Each ensemble member (column of `param_array`) is saved in a separate
+directory "member_<j>" (j=1, ..., N_ens). The name of the saved toml file is
+given by `save_file`; it is the same for all members.
+If an iteration `iter` is given, a directory "iteration_<iter>" is created in
+`save_path`, which contains all the "member_<j>" subdirectories.
+
+Args:
+`param_array` - array of size N_param x N_ens
+`param_distribution` - the parameter distribution underlying `param_array`
+`default_param_data` - dict of default parameters to be combined and saved with
+                       the parameters in `param_array` into a toml file
+`save_path` - path to where the parameters will be saved
+`save_file` - name of the toml files to be generated
+`iter` - the iteration of the ensemble Kalman process represented by the given
+         `param_array`
+"""
+function save_parameter_ensemble(
+    param_array::Array{FT, 2},
+    param_distribution::ParameterDistribution,
+    default_param_data::Dict,
+    save_path::AbstractString,
+    save_file::AbstractString,
+    iter::Union{Int, Nothing}=nothing) where {FT}
+
+    # The parameter values are currently in the unconstrained space
+    # where the ensemble Kalman algorithm takes place
+    save_array = transform_unconstrained_to_constrained(
+        param_distribution,
+        param_array)
+
+    # The number of rows in param_array represent the sum of all parameter
+    # dimensions. We need to determine the slices of rows that belong to
+    # each parameter. E.g., an array with 6 rows could be sliced into
+    # one 1-dim parameter (first row), one 3-dim parameter (rows 2 to 4),
+    # and a 2-dim parameter (rows 5 to 6)
+    param_slices = batch(param_distribution)
+    param_names = get_name(param_distribution)
+
+    N_ens = size(save_array)[2]
+
+    # If needed, create directory where files will be stored
+    save_dir = isnothing(iter) ? save_path : joinpath(save_path, join(["iteration", lpad(iter, 2, "0")], "_"))
+    mkpath(save_dir)
+
+    # Each ensemble member gets its own subdirectory
+    subdir_names = generate_subdir_names(N_ens)
+
+    # All parameter toml files (one for each ensemble member) have the same name
+    toml_file = endswith(save_file, ".toml") ? save_file : save_file * ".toml"
+
+    for i in 1:N_ens
+        mkpath(joinpath(save_dir, subdir_names[i]))
+        # Override the value (or add a value, if no value exists yet)
+        # of the parameter in the original parameter dict with the
+        # corresponding value in param_array
+        param_dict = deepcopy(default_param_data)
+
+        param_dict_updated = assign_values!(
+            i,
+            save_array,
+            param_distribution,
+            param_slices,
+            param_dict,
+            param_names)
+
+        open(joinpath(save_dir, subdir_names[i], toml_file), "w") do io
+            TOML.print(io, param_dict_updated)
+        end
+    end
+end
+
+
+"""
+assign_values!(member, param_array, param_distribution, param_slices,
+param_dict, param_names)
+
+Updates `param_dict` with the values of the given `member` of the `param_array`
+
+Args:
+`member`  - ensemble member (corresponds to column of `param_array`)
+`param_array` - N_par x N_ens array of parameter values
+`param_distribution` - the parameter distribution underlying `param_array`
+`param_slices` - list of contiguous `[collect(1:i), collect(i+1:j),... ]` used
+                 to split parameter arrays by distribution dimensions
+`param_dict` - the dict of parameters to be updated with new parameter values
+`param_names` - names of the parameters
+
+Returns the updated `param_dict`
+"""
+function assign_values!(
+    member::Int,
+    param_array::Array{FT,2},
+    param_distribution::ParameterDistribution,
+    param_slices::Array{Array{Int64,1},1},
+    param_dict::Dict,
+    param_names::Array{String}) where {FT}
+    
+    broadcast_mask = repeat([false], length(param_names))
+    param_names_vec = typeof(param_names) <: AbstractVector ? param_names : [param_names]
+
+    for j in 1:length(param_names_vec)
+
+        if is_broadcast(param_names_vec[j])
+            broadcast_mask[j] = true
+        end
+    end
+
+    merged_param_slices = merge_slices(param_slices, broadcast_mask)
+    merged_param_names = merge_names(param_names_vec)
+
+    for (j, slice) in enumerate(merged_param_slices)
+        value = length(slice) > 1 ? param_array[slice, member] : param_array[slice, member][1]
+        param_dict[merged_param_names[j]]["value"] = value
+    end
+
+    return param_dict
+end
+
+
+function is_broadcast(param_name::AbstractString)
+
+    if endswith(param_name, ")") && occursin("_(", param_name)
+        return true
+    else
+        return false
+    end
+end
+
+
+function merge_names(param_names::Union{AbstractString, Array{String, 1}})
+
+    base_names = first.(split.(param_names, "_("))
+
+    return unique!(base_names)
+end
+
+
+function get_base_name(param_name::Union{AbstractString, Array{String, 1}})
+
+    base_param_name = first.(split.(param_name, "_("))
+
+    return unique!(base_param_name)
+end
+
+
+"""
+merge_slices(param_slices, broadcast_mask)
+
+Merges the slices that belong to broadcast parameters. When writing parameters
+to file, we want to write e.g.
+    [param_i]
+    value = [1.0, 1.5, 0.5, 0.8]
+    prior = "repeat([Parameterized(Normal(1.0, 0.5)], 4)"
+    constraint = "repeat([no_constraint()], 4)"
+
+rather than to write each of the four individual "subparameters" `param_i` gets
+broadcast to internally (`param_i_(1)`, `param_i_(2)`, `param_i_(3)`,
+`param_i_(4)`). This requires merging of the single-dimension parameter slices
+corresponding to these subparameters back into one 4-element slice
+
+Args:
+`param_slices` - array of contiguous `[collect(1:i), collect(i+1:j),... ]` used
+                 to split parameter arrays by distribution dimensions
+`broadcast_mask` - boolean array whose jth element is true if the jth parameter
+                   is broadcast, false otherwise
+
+Returns an array of contiguous `[collect(1:i), collect(i+1:j),... ]` used to
+split parameter arrays by distribution dimensions, where the dimensions of 
+broadcast parameters have been merged into a single slice.
+"""
+function merge_slices(param_slices::Union{Array{Int, 1}, Array{Array{Int, 1}, 1}}, broadcast_mask::Array{Bool, 1})
+
+    @assert(length(param_slices) == length(broadcast_mask))
+
+    merge_slices = [] # slices to be merged
+    for j in 1:length(broadcast_mask)
+        if broadcast_mask[j]
+            if j == 1 || !broadcast_mask[j-1]
+                push!(merge_slices, deepcopy(param_slices[j]))
+            else
+                push!(merge_slices[end], deepcopy(param_slices[j][1]))
+            end
+        end
+    end
+
+    if isempty(merge_slices)
+        # No broadcasting involved
+        return param_slices
+    else
+        combined_slices = sort(vcat(param_slices, merge_slices))
+        delete_indices = []
+        all_merged_indices = vcat(merge_slices...)
+
+        for (i, slice) in enumerate(combined_slices)
+            if (length(slice) == 1) && (slice[1] in all_merged_indices)
+                push!(delete_indices, i)
+            end
+        end
+
+
+        return deleteat!(combined_slices, delete_indices)
+    end
+end
+
+
+"""
+generate_subdir_names(N_ens, prefix="member")
+
+Generates `N_ens` directory names "<prefix>_<i>"; i=1, ..., N_ens
+
+Args:
+`N_ens`  - number of ensemble members (= number of subdirectories)
+`prefix` - prefix used for generation of subdirectory names
+
+Returns a list of directory names
+"""
+function generate_subdir_names(N_ens::Int, prefix::AbstractString="member")
+
+    member(j) = join([prefix, lpad(j, ndigits(N_ens), "0")], "_")
+
+    return [member(j) for j in 1:N_ens]
+end
+
+
+"""
+get_UQ_parameters(param_dict)
+
+Finds all UQ parameters in `param_dict`.
+
+Args:
+`param_dict` - nested dictionary that has parameter names as keys and the
+               corresponding dictionaries of parameter information as values
+
+Returns an array of the names of all UQ parameters in `param_dict`.
+UQ parameters are those parameters that have a key "prior" whose value is not
+set to "fixed". They will enter the uncertainty quantification pipeline.
+"""
+function get_UQ_parameters(param_dict::Dict)
+
+    uq_param = String[]
+
+    for (key, val) in param_dict
+        if haskey(val, "prior") && val["prior"] != "fixed"
+            push!(uq_param, string(key))
+        end
+    end
+
+    return uq_param
+end
+
+
+"""
+write_log_file(param_dict, file_path)
+
+Writes the parameters in `param_dict` into a .toml file
+
+Args:
+`param_dict` - nested dictionary that has parameter names as keys and the
+               corresponding dictionaries of parameter information as values
+`file_path` - path of the file where parameters are saved
+"""
+function write_log_file(param_dict::Dict, file_path::AbstractString) where {FT}
+    open(filepath, "w") do io
+        TOML.print(io, param_dict)
+    end
+end
+

--- a/src/file_parsing_uq.jl
+++ b/src/file_parsing_uq.jl
@@ -5,9 +5,10 @@ using EnsembleKalmanProcesses.ParameterDistributions
 
 # "Public" functions (i.e., functions intended to be called by user):
 #    - read_parameters
-#    - get_UQ_parameters
 #    - get_parameter_distribution
 #    - save_parameter_ensemble
+#    - get_UQ_parameters
+#    - get_regularization
 
 """
 read_parameters(path_to_toml_file)
@@ -32,119 +33,80 @@ end
 
 
 """
-get_parameter_distribution(param_dict, names)
+get_parameter_distribution(param_dict, name)
 
-Construct a `ParameterDistribution` from the prior distribution(s) and
-constraint(s) given in `param_dict`
+Constructs a `ParameterDistribution` for a single parameter
 
 Args:
 `param_dict` - nested dictionary that has parameter names as keys and the
-               corresponding dictionary of parameter information as values
-`names` - list of parameter names or single parameter name
+               corresponding dictionary of parameter information (in particular,
+               the parameters' prior distributions and constraints) as values
+`name` - parameter name
 
 Returns a `ParameterDistribution`
 """
-function get_parameter_distribution(param_dict::Dict, names::Union{AbstractString, Array{String, 1}})
+function get_parameter_distribution(param_dict::Dict, name::AbstractString)
 
-    names_vec = (typeof(names) <: AbstractVector) ? names : [names]
-    n_names = length(names_vec)
-    constraint = []
-    prior = []
-    param_names = []
+    # Constructing a parameter distribution requires a prior distribution,
+    # a constraint, and a name.
+    prior = construct_prior(param_dict[name])
+    constraint = construct_constraint(param_dict[name])
 
-    for name in names_vec
-        # Constructing a parameter distribution requires prior distribution(s),
-        # constraint(s), and name(s).
-        d = construct_prior(param_dict[name])
-        is_array = typeof(d) <: AbstractArray ? true : false
-        ((is_array) && (n_names > 1)) ? push!(prior, d...) : push!(prior, d)
-        c = construct_constraint(param_dict[name], is_array)
-        ((is_array) && (n_names > 1)) ? push!(constraint, c...) : push!(constraint, c)
-        # Names can usually be taken directly from the header of the
-        # corresponding parameter table in the toml file. However, names
-        # have to be generated when the construction of a prameter distribution
-        # involves broadcasting of priors / constraints.
-        if is_array
-            # A broadcast parameter
-            push!(param_names, broadcast_name(name, length(d))...)
-        else
-            # Not a broadcast parameter
-            push!(param_names, name)
-        end
+    return ParameterDistribution(prior, constraint, name)
+end
+
+"""
+get_parameter_distribution(param_dict, names)
+
+Constructs a `ParameterDistribution` for an array of parameters
+
+Args:
+`param_dict` - nested dictionary that has parameter names as keys and the
+               corresponding dictionary of parameter information (in particular,
+               the parameters' prior distributions and constraints) as values
+`names` - array of parameter names
+
+Returns a `ParameterDistribution` 
+"""
+function get_parameter_distribution(param_dict::Dict, names::AbstractVector{String})
+
+    param_dist_arr = Array{ParameterDistribution}(undef, length(names))
+
+    for (i, name) in enumerate(names)
+        param_dist_arr[i] = get_parameter_distribution(param_dict, name)
     end
 
-    if length(vcat(param_names...)) != length(names_vec)
-        # The ParameterDistribution contains at least one broadcast parameter 
-        if typeof(names) <: AbstractString
-            # The broadcast parameter is the only building block of the
-            # parameter distribution
-            return ParameterDistribution(
-                prior[1],
-                constraint[1],
-                identity.(param_names))
-        else
-            # The ParameterDistribution consists of a broadcast parameter and at
-            # least one additional parameter
-            return ParameterDistribution(
-                identity.(prior),
-                identity.(constraint),
-                identity.(param_names))
-        end
+    return combine_distributions(param_dist_arr)
 
-    elseif length(param_names) > 1
-        # The ParameterDistribution consists of multiple parameters
-        return ParameterDistribution(
-            identity.(prior),
-            identity.(constraint),
-            identity.(param_names))
-    else
-        # The ParameterDistribution consists of a single (non-broadcast)
-        # parameter
-        return ParameterDistribution(
-            prior[1],
-            constraint[1],
-            param_names[1])
-    end
 end
 
 
 """
-construct_constraint(param_info, is_array)
+construct_constraint(param_info)
 
 Extracts information on type and arguments of each constraint and uses that
-information to construct an actual `Constraint`.
+information to construct a `Constraint`.
 
 Args:
 `param_info` - dictionary with (at least) a key "constraint", whose value is
                the parameter's constraint(s) (as parsed from TOML file)
 
-`is_array` - true if this constraint is associated with an array of
-             distributions (which typically results from parsing expressions
-             of type "repeat([distribution], n_repetitions)"), false otherwise.
-             Matters for the `ParameterDistribution` constructor, which
-             requires constraints to be given as a list of 1-element lists if
-             `is_array` is true (e.g., [[no_constraint()], [no_constraint()]])
-
-Returns a single `Constraint` if `param_info` only contains one constraint,
-otherwise it returns an array of `Constraint`s
+Returns a `Constraint`
 """
-function construct_constraint(param_info::Dict, is_array::Bool)
+function construct_constraint(param_info::Dict)
 
     @assert(haskey(param_info, "constraint"))
     c = Meta.parse(param_info["constraint"])
 
     if c.args[1] == Symbol("repeat")
-        # There are multiple constraints described by an expression of the
-        # form "repeat([constraint], n_repetitions)"
-        return broadcast_constraint(c, is_array)
+        # Constraints are given as a `repeat` expression defining a vector of
+        # constraints of the same kind
+        constr = collect(c.args[2], "c", repeat=true)
+        n_constr = c.args[3] # number of repeated constraints
+        return repeat([constr], n_constr)
 
-    elseif c.head == Symbol("vect")
-        # There are multiple parameters, hence multiple constraints
-        return get_multidim_constraint(c)
-
-    else
-        # There is only a single 1-dim parameter, hence a single constraint
-        return get_onedim_constraint(c)
+    else 
+        return collect(c, "c")
     end
 end
 
@@ -159,214 +121,105 @@ Args:
 `param_info` - dictionary with (at least) a key "prior", whose value is the
                parameter's distribution(s) (as parsed from TOML file)
 
-Returns a single or array of ParameterDistributionType derived objects
+Returns a distribution of type `Parameterized`, `Samples`, or
+`VectorOfParameterized`
 """
 function construct_prior(param_info::Dict)
 
     @assert(haskey(param_info, "prior"))
     d = Meta.parse(param_info["prior"])
 
-    if d.args[1] == Symbol("repeat")
-        # There are multiple distributions described by an expression of the
-        # form "repeat([distribution], n_repetitions)"
-        return broadcast_prior(d)
-
-    elseif d.head == Symbol("vect")
-        # Multiple distributions
-        return get_multidim_prior(d)
+    if d.args[1] == Symbol("VectorOfParameterized")
+        # There are multiple distributions described by a
+        # `VectorOfParameterized`
+        return get_vector_of_parameterized(d)
 
     else
         # Single distribution
-        return get_onedim_prior(d)
+        return get_distribution(d)
     end
 end
 
 
 """
-broadcast_name(base_name, n_repetitions)
+get_vector_of_parameterized(d)
 
-Generates numbered parameter names <base_name>_(<i>); i in 1, ..., n_repetitions
-Example:
-    broadcast_name("my_param", 3)
-    returns ["my_param_(1)", "my_param_(2)", "my_param_(3)"]
+Parses a distribution of type `VectorOfParameterized`
 
 Args:
-`base_name` - base name to which numbers will be added
-`n_repetitions` - number of derived parameter names to generate from `base_name`
+`d`  - expression containing the distribution information
 
-Returns an array of length n_repetitions
+Returns a `VectorOfParameterized`
 """
-function broadcast_name(base_name::AbstractString, n_repetitions::Int)
+function get_vector_of_parameterized(d::Expr)
 
-    param_name(j) = base_name * "_(" * lpad(j,ndigits(n_repetitions), "0") * ")"
+    @assert(d.args[1] == Symbol("VectorOfParameterized"))
 
-    return [param_name(j) for j in 1:n_repetitions]
-end
+    if d.args[2].args[1] == Symbol("repeat")
+        # Distributions are given as a `repeat` expression defining a vector of
+        # distributions of the same kind
+        dist = collect(d.args[2].args[2], "d", repeat=true)
+        n_dist = d.args[2].args[3] # number of repeated distributions
+        return VectorOfParameterized(repeat([dist], n_dist))
 
-
-"""
-broadcast_constraint(expr, is_array)
-
-Constructs an array of constraints from an expression of the sort
-    "repeat([no_constraint], 10)",
-    "repeat([[bounded_below(0.3)]], 100),
-    etc.
-
-Args:
-`expr`  - expression with expr.args[1] == Symbol("repeat")
-`is_array` - true if this constraint is associated with an array of
-             distributions (which typically results from parsing expressions
-             of type "repeat([distribution], n_repetitions)"), false otherwise.
-
-Returns an array of constraints
-"""
-function broadcast_constraint(c::Expr, is_array::Bool)
-
-    @assert(c.args[1] == Symbol("repeat"))
-    n_repetitions  = c.args[3]
-    if is_array
-        constraint = get_onedim_constraint(c.args[2].args[1].args[1])
-        return repeat([[constraint]], n_repetitions)
     else
-        constraint = get_onedim_constraint(c.args[2].args[1])
-        return repeat([constraint], n_repetitions)
+        # Distributions are given as an array of distributions listing each
+        # individual distribution explicitly
+        dist_arr = collect(d.args[2], "d")
+        return VectorOfParameterized(dist_arr)
     end
+
 end
 
 
 """
-get_multidim_constraints(c)
+collect(e, eltype; repeat=false)
 
-Parses multidimensional constraints
+Collects distributions or constraints
 
 Args:
-`c`  - expression containing the constraint information
+`e`  - expression containing the distribution or constraint information
+`eltype` - string denoting the type of elements that are collected, "d" for
+           distributions, "c" for constraints
+`repeat` - true if this distribution or constraint is given as a `repeat(...)`
+           expression, false otherwise
 
-Returns an array of `Constraint`s
+Returns an array of distributions / constraints, or a single distribution /
+constraint if only one is present
 """
-function get_multidim_constraint(c::Expr)
+function collect(e::Expr, eltype::AbstractString; repeat::Bool=false)
 
-    constraints = []
-    constraint_groups = c.args
-    n_constraint_groups = length(c.args)
+    if e.head == Symbol("vect")
+        # There are multiple distributions / constraints 
+        n_elem = length(e.args) # number of elements
+        arr = (eltype == "d") ? Array{Distribution}(undef, n_elem) : Array{ConstraintType}(undef, n_elem)
 
-    for i in 1:n_constraint_groups
-
-        if constraint_groups[i].head == Symbol("vect")
-            # This is a multidimensional parameter
-            n_param_constraints = length(constraint_groups[i].args)
-            param_constraints = []
-
-            for j in 1:n_param_constraints
-                push!(
-                    param_constraints,
-                    getfield(Main, constraint_groups[i].args[j].args[1])(
-                        constraint_groups[i].args[j].args[2:end]...)
-                )
-            end
-
-            push!(constraints, param_constraints)
-
-        else
-            # This is a single parameter
-            push!(constraints,
-                  getfield(Main, constraint_groups[i].args[1])(
-                      constraint_groups[i].args[2:end]...))
+        for i in 1:n_elem
+            elem = e.args[i]
+            arr[i] = getfield(Main, elem.args[1])(elem.args[2:end]...)
         end
+
+        return repeat ? arr[1] : arr
+
+    else
+        # There is a single distribution / constraint
+        return getfield(Main, e.args[1])(e.args[2:end]...)
     end
 
-    return [constraints[i] for i in 1:length(constraints)]
 end
 
 
 """
-get_onedim_constraint(c)
+get_distribution(d)
 
-Parses a one-dimensional constraint
-
-Args:
-`c`  - expression containing the constraint information
-
-Returns a `Constraint`
-"""
-function get_onedim_constraint(c::Expr)
-
-    return getfield(Main, c.args[1])(c.args[2:end]...)
-end
-
-
-"""
-broadcast_prior(d)
-
-Constructs an array of constraints or distributions from an expression of
-the sort
-    "repeat([Parameterized(Gamma(2.0, 3.0))], 50)",
-    "repeat([Samples([1.0 1.5 2.0; 0.7 1.2 1.8])], 100)",
-    etc.
-
-Args:
-`d`  - expression with expr.args[1] == Symbol("repeat")
-
-Returns an array of prior distributions
-"""
-function broadcast_prior(d::Expr)
-
-    @assert(d.args[1] == Symbol("repeat"))
-    prior = get_onedim_prior(d.args[2].args[1])
-    n_repetitions = d.args[3]
-
-    return repeat([prior], n_repetitions)
-end
-
-
-"""
-get_multidim_prior(d)
-
-Parses multidimensional prior distributions
+Parses a distribution
 
 Args:
 `d`  - expression containing the distribution information
 
-Returns an array of prior distributions (`Parameterized` or `Samples`)
+Returns a distribution of type `Parameterized` or `Samples`
 """
-function get_multidim_prior(d::Expr)
-
-    n_distributions = length(d.args)
-    distributions = Array{ParameterDistributionType}(undef, n_distributions)
-
-    for i in range(1, stop=n_distributions)
-        dist_type_symb = d.args[i].args[1]
-        dist_type = getfield(Main, dist_type_symb)
-
-        if dist_type_symb == Symbol("Parameterized")
-            dist = getfield(Main, d.args[i].args[2].args[1])
-            dist_args = d.args[i].args[2].args[2:end]
-            distributions[i] = dist_type(dist(dist_args...))
-
-        elseif dist_type_symb == Symbol("Samples")
-            dist_args = construct_2d_array(d.args[i].args[2])
-            distributions[i] = dist_type(dist_args)
-
-        else
-            throw(error("Unknown distribution type ", dist_type))
-        end
-    end
-
-    return distributions
-end
-
-
-"""
-get_onedim_prior(d)
-
-Parses a one-dimensional prior distributions
-
-Args:
-`d`  - expression containing the distribution information
-
-Returns a single prior distributions (`Parameterized` or `Samples`)
-"""
-function get_onedim_prior(d::Expr)
+function get_distribution(d::Expr)
 
     dist_type_symb = d.args[1]
     dist_type = getfield(Main, dist_type_symb)
@@ -460,7 +313,7 @@ function save_parameter_ensemble(
 
     N_ens = size(save_array)[2]
 
-    # If needed, create directory where files will be stored
+    # Create directory where files will be stored if it doesn't exist yet
     save_dir = isnothing(iter) ? save_path : joinpath(save_path, join(["iteration", lpad(iter, 2, "0")], "_"))
     mkpath(save_dir)
 
@@ -494,7 +347,7 @@ end
 
 """
 assign_values!(member, param_array, param_distribution, param_slices,
-param_dict, param_names)
+param_dict, names)
 
 Updates `param_dict` with the values of the given `member` of the `param_array`
 
@@ -505,7 +358,7 @@ Args:
 `param_slices` - list of contiguous `[collect(1:i), collect(i+1:j),... ]` used
                  to split parameter arrays by distribution dimensions
 `param_dict` - the dict of parameters to be updated with new parameter values
-`param_names` - names of the parameters
+`names` - array of parameter names
 
 Returns the updated `param_dict`
 """
@@ -515,113 +368,16 @@ function assign_values!(
     param_distribution::ParameterDistribution,
     param_slices::Array{Array{Int64,1},1},
     param_dict::Dict,
-    param_names::Array{String}) where {FT}
+    names::AbstractVector{String}) where {FT}
     
-    broadcast_mask = repeat([false], length(param_names))
-    param_names_vec = typeof(param_names) <: AbstractVector ? param_names : [param_names]
+    param_names_vec = typeof(names) <: AbstractVector ? names : [names]
 
-    for j in 1:length(param_names_vec)
-
-        if is_broadcast(param_names_vec[j])
-            broadcast_mask[j] = true
-        end
-    end
-
-    merged_param_slices = merge_slices(param_slices, broadcast_mask)
-    merged_param_names = merge_names(param_names_vec)
-
-    for (j, slice) in enumerate(merged_param_slices)
+    for (j, slice) in enumerate(param_slices)
         value = length(slice) > 1 ? param_array[slice, member] : param_array[slice, member][1]
-        param_dict[merged_param_names[j]]["value"] = value
+        param_dict[param_names_vec[j]]["value"] = value
     end
 
     return param_dict
-end
-
-
-function is_broadcast(param_name::AbstractString)
-
-    if endswith(param_name, ")") && occursin("_(", param_name)
-        return true
-    else
-        return false
-    end
-end
-
-
-function merge_names(param_names::Union{AbstractString, Array{String, 1}})
-
-    base_names = first.(split.(param_names, "_("))
-
-    return unique!(base_names)
-end
-
-
-function get_base_name(param_name::Union{AbstractString, Array{String, 1}})
-
-    base_param_name = first.(split.(param_name, "_("))
-
-    return unique!(base_param_name)
-end
-
-
-"""
-merge_slices(param_slices, broadcast_mask)
-
-Merges the slices that belong to broadcast parameters. When writing parameters
-to file, we want to write e.g.
-    [param_i]
-    value = [1.0, 1.5, 0.5, 0.8]
-    prior = "repeat([Parameterized(Normal(1.0, 0.5)], 4)"
-    constraint = "repeat([no_constraint()], 4)"
-
-rather than to write each of the four individual "subparameters" `param_i` gets
-broadcast to internally (`param_i_(1)`, `param_i_(2)`, `param_i_(3)`,
-`param_i_(4)`). This requires merging of the single-dimension parameter slices
-corresponding to these subparameters back into one 4-element slice
-
-Args:
-`param_slices` - array of contiguous `[collect(1:i), collect(i+1:j),... ]` used
-                 to split parameter arrays by distribution dimensions
-`broadcast_mask` - boolean array whose jth element is true if the jth parameter
-                   is broadcast, false otherwise
-
-Returns an array of contiguous `[collect(1:i), collect(i+1:j),... ]` used to
-split parameter arrays by distribution dimensions, where the dimensions of 
-broadcast parameters have been merged into a single slice.
-"""
-function merge_slices(param_slices::Union{Array{Int, 1}, Array{Array{Int, 1}, 1}}, broadcast_mask::Array{Bool, 1})
-
-    @assert(length(param_slices) == length(broadcast_mask))
-
-    merge_slices = [] # slices to be merged
-    for j in 1:length(broadcast_mask)
-        if broadcast_mask[j]
-            if j == 1 || !broadcast_mask[j-1]
-                push!(merge_slices, deepcopy(param_slices[j]))
-            else
-                push!(merge_slices[end], deepcopy(param_slices[j][1]))
-            end
-        end
-    end
-
-    if isempty(merge_slices)
-        # No broadcasting involved
-        return param_slices
-    else
-        combined_slices = sort(vcat(param_slices, merge_slices))
-        delete_indices = []
-        all_merged_indices = vcat(merge_slices...)
-
-        for (i, slice) in enumerate(combined_slices)
-            if (length(slice) == 1) && (slice[1] in all_merged_indices)
-                push!(delete_indices, i)
-            end
-        end
-
-
-        return deleteat!(combined_slices, delete_indices)
-    end
 end
 
 
@@ -682,8 +438,70 @@ Args:
 `file_path` - path of the file where parameters are saved
 """
 function write_log_file(param_dict::Dict, file_path::AbstractString) where {FT}
-    open(filepath, "w") do io
+    open(file_path, "w") do io
         TOML.print(io, param_dict)
     end
+end
+
+
+"""
+get_regularization(param_dict, name)
+
+Returns the regularization information for a single parameter
+
+Args:
+`param_dict` - nested dictionary that has parameter names as keys and the
+               corresponding dictionary of parameter information as values
+`name` - parameter name
+
+Returns a tuple (<regularization_type>, <regularization_value>), where the
+regularization type is either "L1" or "L2", and the regularization value is
+a float. Returns (nothing, nothing) if parameter has no regularization
+information.
+"""
+function get_regularization(param_dict::Dict, name::AbstractString)
+    
+    if haskey(param_dict[name], "L1") && haskey(param_dict[name], "L2")
+        # There can't be more than one regularization flag
+        throw(ErrorException("Only one regularization flag (either 'L1' or " *
+            "'L2') is allowed"))
+    elseif haskey(param_dict[name], "L1")
+        # L1 regularization
+        return ("L1", param_dict[name]["L1"])
+    elseif haskey(param_dict[name], "L2")
+        # L1 regularization
+        return ("L2", param_dict[name]["L2"])
+    else
+        # No regularization
+        return (nothing, nothing)
+    end
+end
+
+
+"""
+get_regularization(param_dict, names)
+
+Returns the regularization information for an array of parameters
+
+Args:
+`param_dict` - nested dictionary that has parameter names as keys and the
+               corresponding dictionary of parameter information as values
+`names` - array of parameter names
+
+Returns an arary of tuples (<regularization_type>, <regularization_value>), with
+the ith tuple corresponding to the parameter `names[i]`. The regularization
+type is either "L1" or "L2", and the regularization value is a float.
+Returns (nothing, nothing) for parameters that have no regularization
+information.
+"""
+function get_regularization(param_dict::Dict, names::AbstractVector{String})
+
+    regularr = []
+
+    for name in names
+        push!(regularr, get_regularization(param_dict, name))
+    end
+
+    return regularr
 end
 

--- a/src/parameters.toml
+++ b/src/parameters.toml
@@ -1,71 +1,71 @@
 [prandtl_number_0_businger]
-alias = "Pr_0"
+alias = "Pr_0_Businger"
 value = 0.74
 type = "float"
 
 [coefficient_a_m_businger]
-alias = "a_m"
+alias = "a_m_Businger"
 value = 4.7
 type = "float"
 
 [coefficient_a_h_businger]
-alias = "a_h"
+alias = "a_h_Businger"
 value = 4.7
 type = "float"
 
 [prandtl_number_0_gryanik]
-alias = "Pr_0"
+alias = "Pr_0_Gryanik"
 value = 0.98
 type = "float"
 
 [coefficient_a_m_gryanik]
-alias = "a_m"
+alias = "a_m_Gryanik"
 value = 5.0
 type = "float"
 
 [coefficient_a_h_gryanik]
-alias = "a_h"
+alias = "a_h_Gryanik"
 value = 5.0
 type = "float"
 
 [coefficient_b_m_gryanik]
-alias = "b_m"
+alias = "b_m_Gryanik"
 value = 0.3
 type = "float"
 
 [coefficient_b_h_gryanik]
-alias = "b_h"
+alias = "b_h_Gryanik"
 value = 0.4
 type = "float"
 
 [prandtl_number_0_grachev]
-alias = "Pr_0"
+alias = "Pr_0_Grachev"
 value = 0.98
 type = "float"
 
 [coefficient_a_m_grachev]
-alias = "a_m"
+alias = "a_m_Grachev"
 value = 5.0
 type = "float"
 
 [coefficient_a_h_grachev]
-alias = "a_h"
+alias = "a_h_Grachev"
 value = 5.0
 type = "float"
 
 [coefficient_b_m_grachev]
-alias = "b_m"
+alias = "b_m_Grachev"
 value = 0.7692307692307693
 type = "float"
 description = "derived [coefficient_a_m_grachev] / 6.5"
 
 [coefficient_b_h_grachev]
-alias = "b_h"
+alias = "b_h_Grachev"
 value = 5.0
 type = "float"
 
 [coefficient_c_h_grachev]
-alias = "c_h"
+alias = "c_h_Grachev"
 value = 3.0
 type = "float"
 

--- a/src/parameters.toml
+++ b/src/parameters.toml
@@ -1,3 +1,84 @@
+[prandtl_number_0_businger]
+alias = "Pr_0_Businger"
+value = 0.74
+type = "float"
+
+[coefficient_a_m_businger]
+alias = "a_m_Businger"
+value = 4.7
+type = "float"
+
+[coefficient_a_h_businger]
+alias = "a_h_Businger"
+value = 4.7
+type = "float"
+
+[prandtl_number_0_gryanik]
+alias = "Pr_0_Gryanik"
+value = 0.98
+type = "float"
+
+[coefficient_a_m_gryanik]
+alias = "a_m_Gryanik"
+value = 5.0
+type = "float"
+
+[coefficient_a_h_gryanik]
+alias = "a_h_Gryanik"
+value = 5.0
+type = "float"
+
+[coefficient_b_m_gryanik]
+alias = "b_m_Gryanik"
+value = 0.3
+type = "float"
+
+[coefficient_b_h_gryanik]
+alias = "b_h_Gryanik"
+value = 0.4
+type = "float"
+
+[prandtl_number_0_grachev]
+alias = "Pr_0_Grachev"
+value = 0.98
+type = "float"
+
+[coefficient_a_m_grachev]
+alias = "a_m_Grachev"
+value = 5.0
+type = "float"
+
+[coefficient_a_h_grachev]
+alias = "a_h_Grachev"
+value = 5.0
+type = "float"
+
+[coefficient_b_m_grachev]
+alias = "b_m_Grachev"
+value = 0.7692307692307693
+type = "float"
+description = "derived [coefficient_a_m_grachev] / 6.5"
+
+[coefficient_b_h_grachev]
+alias = "b_h_Grachev"
+value = 5.0
+type = "float"
+
+[coefficient_c_h_grachev]
+alias = "c_h_Grachev"
+value = 3.0
+type = "float"
+
+[von_karman_constant]
+alias = "von_karman_const"
+value = 0.4
+type = "float"
+
+
+
+# microphysics
+
+
 [precipitation_timescale]
 alias = "τ_precip"
 value = 1000
@@ -255,15 +336,7 @@ type = "float"
 
 
 
-
-
-
-
 # Initial planet_parameters toml file
-
-
-
-
 
 
 

--- a/src/parameters.toml
+++ b/src/parameters.toml
@@ -1,71 +1,71 @@
 [prandtl_number_0_businger]
-alias = "Pr_0_Businger"
+alias = "Pr_0"
 value = 0.74
 type = "float"
 
 [coefficient_a_m_businger]
-alias = "a_m_Businger"
+alias = "a_m"
 value = 4.7
 type = "float"
 
 [coefficient_a_h_businger]
-alias = "a_h_Businger"
+alias = "a_h"
 value = 4.7
 type = "float"
 
 [prandtl_number_0_gryanik]
-alias = "Pr_0_Gryanik"
+alias = "Pr_0"
 value = 0.98
 type = "float"
 
 [coefficient_a_m_gryanik]
-alias = "a_m_Gryanik"
+alias = "a_m"
 value = 5.0
 type = "float"
 
 [coefficient_a_h_gryanik]
-alias = "a_h_Gryanik"
+alias = "a_h"
 value = 5.0
 type = "float"
 
 [coefficient_b_m_gryanik]
-alias = "b_m_Gryanik"
+alias = "b_m"
 value = 0.3
 type = "float"
 
 [coefficient_b_h_gryanik]
-alias = "b_h_Gryanik"
+alias = "b_h"
 value = 0.4
 type = "float"
 
 [prandtl_number_0_grachev]
-alias = "Pr_0_Grachev"
+alias = "Pr_0"
 value = 0.98
 type = "float"
 
 [coefficient_a_m_grachev]
-alias = "a_m_Grachev"
+alias = "a_m"
 value = 5.0
 type = "float"
 
 [coefficient_a_h_grachev]
-alias = "a_h_Grachev"
+alias = "a_h"
 value = 5.0
 type = "float"
 
 [coefficient_b_m_grachev]
-alias = "b_m_Grachev"
+alias = "b_m"
 value = 0.7692307692307693
 type = "float"
 description = "derived [coefficient_a_m_grachev] / 6.5"
 
 [coefficient_b_h_grachev]
-alias = "b_h_Grachev"
+alias = "b_h"
 value = 5.0
 type = "float"
 
 [coefficient_c_h_grachev]
-alias = "c_h_Grachev"
+alias = "c_h"
 value = 3.0
 type = "float"
 

--- a/test/array_parameters.toml
+++ b/test/array_parameters.toml
@@ -1,0 +1,14 @@
+[array_parameter_1]
+alias = "arr_1"
+value = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0]
+type = "float"
+
+[array_parameter_2]
+alias = "arr_2"
+value = [0.0, 1.0, 1.0, 2.0, 3.0, 5.0, 8.0, 13.0, 21.0, 34.0]
+type = "float"
+
+[gravitational_acceleration]
+alias = "grav"
+value = [9.81, 10.0]
+type = "float"

--- a/test/override_typos.toml
+++ b/test/override_typos.toml
@@ -2,3 +2,8 @@
 value = 10.0
 type = "float"
 alias = "light_spede"
+
+[light_speed]
+value = 10000.0
+type = "float"
+alias = "light_speed"

--- a/test/override_typos.toml
+++ b/test/override_typos.toml
@@ -1,0 +1,4 @@
+[light_spede]
+value = 10.0
+type = "float"
+alias = "light_spede"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
-
 include("toml_consistency.jl")
+
 include("planet.jl")
 include("subgrid_scale.jl")
 include("edmf.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,5 @@
 include("toml_consistency.jl")
+include("uq_parameters.jl")
 
 include("planet.jl")
 include("subgrid_scale.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,9 +1,4 @@
 
-
-# read parameters needed for tests
-import CLIMAParameters
-src_parameter_dict = CLIMAParameters.create_parameter_dict(dict_type = "alias")
-
 include("toml_consistency.jl")
 include("planet.jl")
 include("subgrid_scale.jl")

--- a/test/toml_consistency.jl
+++ b/test/toml_consistency.jl
@@ -1,11 +1,12 @@
 using Test
 
-# read parameters needed for tests
-import CLIMAParameters
-full_parameter_set = CLIMAParameters.create_parameter_struct(dict_type = "alias")
-
 # import CLIMAParameters
+import CLIMAParameters
 const CP = CLIMAParameters
+
+# read parameters needed for tests
+full_parameter_set = CP.create_parameter_struct(dict_type="alias")
+
 const CPP = CP.Planet
 struct EarthParameterSet <: CP.AbstractEarthParameterSet end
 const param_set_cpp = EarthParameterSet()
@@ -20,28 +21,29 @@ universal_constant_aliases = [
     "avogad",
 ]
 
-@testset "parameter_consistency" begin
+@testset "CLIMA_parameter_consistency" begin
 
     # tests to check parameter consistency of new toml files with existing
     # CP defaults.
     
     # CP modules list:
     module_names = [
-    CLIMAParameters,
-    CLIMAParameters.Planet,
-    CLIMAParameters.SubgridScale,
-    # CLIMAParameters.Atmos.EDMF,
-    # CLIMAParameters.Atmos.SubgridScale,
-    CLIMAParameters.Atmos.Microphysics_0M,
-    CLIMAParameters.Atmos.Microphysics,
-    CLIMAParameters.SurfaceFluxes.UniversalFunctions,
+    CP,
+    CP.Planet,
+    CP.SubgridScale,
+    # CP.Atmos.EDMF,
+    # CP.Atmos.SubgridScale,
+    CP.Atmos.Microphysics_0M,
+    CP.Atmos.Microphysics,
+    CP.SurfaceFluxes.UniversalFunctions,
     ]
     CP_parameters = Dict(mod => String.(names(mod)) for mod in module_names)
     
     k_found=[0]
     for (k, v) in full_parameter_set #iterates over data (by alias) 
+
         for mod in module_names
-            k_value = CLIMAParameters.get_parameter_values(full_parameter_set, k) 
+            k_value = CP.get_parameter_values(full_parameter_set, k) 
             if k in CP_parameters[mod]
                 k_found[1] = 1
                 cp_k = getfield(mod, Symbol(k))                 
@@ -51,7 +53,7 @@ universal_constant_aliases = [
                     @test (k_value ≈ cp_k())
                 end
                 #for the logfile test later:
-                CLIMAParameters.get_parameter_values!(full_parameter_set, k, mod) 
+                CP.get_parameter_values!(full_parameter_set, k, mod) 
             end
         end
         if k_found[1] == 0
@@ -63,15 +65,15 @@ universal_constant_aliases = [
     end
 
     #create a dummy log file listing where CLIMAParameter lives
-    logfilepath = joinpath(@__DIR__,"log_file_test.toml")
-    CLIMAParameters.write_log_file(full_parameter_set,logfilepath)
+    logfilepath = joinpath(@__DIR__,"log_file_test_1.toml")
+    CP.write_log_file(full_parameter_set, logfilepath)
 
     #read in log file as new parameter file and rerun test.
-    full_parameter_set_from_log = CLIMAParameters.create_parameter_struct(logfilepath,dict_type = "alias")
+    full_parameter_set_from_log = CP.create_parameter_struct(logfilepath,dict_type = "alias")
     k_found=[0]
     for (k, v) in full_parameter_set_from_log #iterates over data (by alias) 
         for mod in module_names
-            k_value = CLIMAParameters.get_parameter_values(full_parameter_set_from_log, k) 
+            k_value = CP.get_parameter_values(full_parameter_set_from_log, k) 
             if k in CP_parameters[mod]
                 k_found[1] = 1
                 cp_k = getfield(mod, Symbol(k))                 
@@ -89,7 +91,71 @@ universal_constant_aliases = [
         k_found[1] = 0
     end
     
-                   
-    
 
+    # Tests to check if file parsing, extracting and logging of parameter
+    # values also works with array-valued parameters
+
+    # Create parameter structs consisting of the parameters contained in the
+    # default parameter file ("parameters.toml") and additional (array valued)
+    # parameters ("array_parameters.toml"). 
+    path_to_array_params = joinpath(splitpath(pathof(CP))[1:end-2]...,"test/array_parameters.toml")
+    # parameter struct of type Float64 (default)
+    param_set = CP.create_parameter_struct(path_to_array_params,
+                                           dict_type="name")
+    # parameter struct of type Float32
+    param_set_f32 = CP.create_parameter_struct(path_to_array_params,
+                                               dict_type="name",
+                                               value_type=Float32)
+
+    # true parameter values (used to check if values are correctly read from
+    # the toml file)
+    true_param_1 = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0]
+    true_param_2 = [0.0, 1.0, 1.0, 2.0, 3.0, 5.0, 8.0, 13.0, 21.0, 34.0]
+    true_param_3 = [9.81, 10.0]
+    true_param_4 = 299792458 
+    true_params = [true_param_1, true_param_2, true_param_3, true_param_4]
+    param_names = ["array_parameter_1", "array_parameter_2",
+                   "gravitational_acceleration", "light_speed"]
+
+    # Let's assume that parameter_vector_1 and parameter_vector_2 are used
+    # in a module called "Test"
+    mod = "Test"
+
+    # Get parameter values and add information on the module where the
+    # parameters are used. 
+    for i in range(1, stop=length(true_params))
+
+        param = CP.get_parameter_values!(param_set, param_names[i], mod)
+        @test param == true_params[i]
+        # Check if the parameter is of the correct type. It should have
+        # the same type as the ParamDict, which is specified by the
+        # `value_type`` argument to `create_parameter_struct`.
+        @test eltype(param) == Float64
+
+        param_f32 = CP.get_parameter_values!(param_set_f32, param_names[i], mod)
+        @test eltype(param_f32) == Float32
+
+    end
+
+    # Get several parameter values (scalar and arrays) at once
+    params = CP.get_parameter_values(param_set, param_names)
+    for j in 1:length(param_names)
+        @test params[j] == true_params[j]
+    end
+    
+    # Write parameters to log file
+    logfilepath = joinpath(@__DIR__, "log_file_test_2.toml")
+    CP.write_log_file(param_set, logfilepath)
+
+    # `param_set` and `full_param_set` contain different values for the
+    # `gravitational_acceleration` parameter. The merged parameter set should
+    # contain the value from `param_set`.
+    full_param_set = CP.create_parameter_struct(dict_type="name")
+    merged_param_set = CP.merge_override_default_values(param_set,
+                                                        full_param_set,
+                                                        )
+    grav = CP.get_parameter_values(merged_param_set,
+                                   "gravitational_acceleration")
+    @test grav == true_param_3
+    
 end

--- a/test/toml_consistency.jl
+++ b/test/toml_consistency.jl
@@ -174,6 +174,8 @@ logfilepath3 = joinpath(@__DIR__, "log_file_test_3.toml")
 
     @testset "checks for overrides" begin
         full_param_set = CP.create_parameter_struct(joinpath(@__DIR__,"override_typos.toml"), dict_type="name")
+        mod = "test_module_name"
+        CP.get_parameter_values!(full_param_set, "light_speed", mod) 
         @test_logs (:warn,) CP.log_parameter_information(full_param_set, logfilepath3)
         @test_throws ErrorException CP.log_parameter_information(full_param_set, logfilepath3, warn_else_error="error")
     end

--- a/test/toml_consistency.jl
+++ b/test/toml_consistency.jl
@@ -34,8 +34,7 @@ universal_constant_aliases = [
     # CLIMAParameters.Atmos.SubgridScale,
     CLIMAParameters.Atmos.Microphysics_0M,
     CLIMAParameters.Atmos.Microphysics,
-    #CLIMAParameters.SurfaceFluxes.UniversalFunctions,
-    # NB: Cannot do universal functions - as I have changed the aliases (removing _Businger etc. suffixes)
+    CLIMAParameters.SurfaceFluxes.UniversalFunctions,
     ]
     CP_parameters = Dict(mod => String.(names(mod)) for mod in module_names)
     

--- a/test/toml_consistency.jl
+++ b/test/toml_consistency.jl
@@ -34,7 +34,8 @@ universal_constant_aliases = [
     # CLIMAParameters.Atmos.SubgridScale,
     CLIMAParameters.Atmos.Microphysics_0M,
     CLIMAParameters.Atmos.Microphysics,
-    CLIMAParameters.SurfaceFluxes.UniversalFunctions,
+    #CLIMAParameters.SurfaceFluxes.UniversalFunctions,
+    # NB: Cannot do universal functions - as I have changed the aliases (removing _Businger etc. suffixes)
     ]
     CP_parameters = Dict(mod => String.(names(mod)) for mod in module_names)
     
@@ -55,9 +56,10 @@ universal_constant_aliases = [
             end
         end
         if k_found[1] == 0
-            println("on trying alias", k)
-            throw("did not find in any modules")
+            println("on trying alias: ", k)
+            @warn("did not find in any modules")
         end
+        
         k_found[1] = 0
     end
 
@@ -82,8 +84,8 @@ universal_constant_aliases = [
             end
         end
         if k_found[1] == 0
-            println("on trying alias", k)
-            throw("did not find in any modules")
+            println("on trying alias: ", k)
+            @warn("did not find in any modules")
         end
         k_found[1] = 0
     end

--- a/test/toml_consistency.jl
+++ b/test/toml_consistency.jl
@@ -29,12 +29,12 @@ universal_constant_aliases = [
     module_names = [
     CLIMAParameters,
     CLIMAParameters.Planet,
-    #CLIMAParameters.SubgridScale,
-    #CLIMAParameters.Atmos.EDMF,
+    CLIMAParameters.SubgridScale,
+    # CLIMAParameters.Atmos.EDMF,
+    # CLIMAParameters.Atmos.SubgridScale,
     CLIMAParameters.Atmos.Microphysics_0M,
     CLIMAParameters.Atmos.Microphysics,
-    #CLIMAParameters.Atmos.SubgridScale,
-    #CLIMAParameters.SurfaceFluxes.UniversalFunctions,
+    CLIMAParameters.SurfaceFluxes.UniversalFunctions,
     ]
     CP_parameters = Dict(mod => String.(names(mod)) for mod in module_names)
     

--- a/test/toml_consistency.jl
+++ b/test/toml_consistency.jl
@@ -21,13 +21,8 @@ universal_constant_aliases = [
     "avogad",
 ]
 
-@testset "CLIMA_parameter_consistency" begin
-
-    # tests to check parameter consistency of new toml files with existing
-    # CP defaults.
-    
-    # CP modules list:
-    module_names = [
+# CP modules list:
+module_names = [
     CP,
     CP.Planet,
     CP.SubgridScale,
@@ -36,126 +31,152 @@ universal_constant_aliases = [
     CP.Atmos.Microphysics_0M,
     CP.Atmos.Microphysics,
     CP.SurfaceFluxes.UniversalFunctions,
-    ]
-    CP_parameters = Dict(mod => String.(names(mod)) for mod in module_names)
-    
-    k_found=[0]
-    for (k, v) in full_parameter_set #iterates over data (by alias) 
+]
 
-        for mod in module_names
-            k_value = CP.get_parameter_values(full_parameter_set, k) 
-            if k in CP_parameters[mod]
-                k_found[1] = 1
-                cp_k = getfield(mod, Symbol(k))                 
-                if ~(k in universal_constant_aliases)
-                    @test (k_value ≈ cp_k(param_set_cpp))
-                else #universal parameters have no argument
-                    @test (k_value ≈ cp_k())
+CP_parameters = Dict(mod => String.(names(mod)) for mod in module_names)
+logfilepath1 = joinpath(@__DIR__, "log_file_test_1.toml")
+logfilepath2 = joinpath(@__DIR__, "log_file_test_2.toml")
+logfilepath3 = joinpath(@__DIR__, "log_file_test_3.toml")
+
+@testset "parameter file interface tests" begin
+    
+    @testset "TOML - CliMAParameters.jl consistency" begin    
+        # tests to check parameter consistency of new toml files with existing
+        # CP defaults.
+        
+        
+        
+        k_found=[0]
+        for (k, v) in full_parameter_set #iterates over data (by alias) 
+            
+            for mod in module_names
+                k_value = CP.get_parameter_values(full_parameter_set, k) 
+                if k in CP_parameters[mod]
+                    k_found[1] = 1
+                    cp_k = getfield(mod, Symbol(k))                 
+                    if ~(k in universal_constant_aliases)
+                        @test (k_value ≈ cp_k(param_set_cpp))
+                    else #universal parameters have no argument
+                        @test (k_value ≈ cp_k())
+                    end
+                    #for the logfile test later:
+                    CP.get_parameter_values!(full_parameter_set, k, mod) 
                 end
-                #for the logfile test later:
-                CP.get_parameter_values!(full_parameter_set, k, mod) 
             end
+            if k_found[1] == 0
+                println("on trying alias: ", k)
+                @warn("did not find in any modules")
+            end
+            
+            k_found[1] = 0
         end
-        if k_found[1] == 0
-            println("on trying alias: ", k)
-            @warn("did not find in any modules")
+
+        #create a dummy log file listing where CLIMAParameter lives
+        CP.write_log_file(full_parameter_set, logfilepath1)
+    end
+    
+    @testset "Parameter logging" begin
+        
+
+        #read in log file as new parameter file and rerun test.
+        full_parameter_set_from_log = CP.create_parameter_struct(logfilepath1,dict_type = "alias")
+        k_found=[0]
+        for (k, v) in full_parameter_set_from_log #iterates over data (by alias) 
+            for mod in module_names
+                k_value = CP.get_parameter_values(full_parameter_set_from_log, k) 
+                if k in CP_parameters[mod]
+                    k_found[1] = 1
+                    cp_k = getfield(mod, Symbol(k))                 
+                    if ~(k in universal_constant_aliases)
+                        @test (k_value ≈ cp_k(param_set_cpp))
+                    else #universal parameters have no argument
+                        @test (k_value ≈ cp_k())
+                    end
+                end
+            end
+            if k_found[1] == 0
+                println("on trying alias: ", k)
+                @warn("did not find in any modules")
+            end
+            k_found[1] = 0
+        end
+    end
+
+    @testset "parameter arrays" begin
+        # Tests to check if file parsing, extracting and logging of parameter
+        # values also works with array-valued parameters
+        
+        # Create parameter structs consisting of the parameters contained in the
+        # default parameter file ("parameters.toml") and additional (array valued)
+        # parameters ("array_parameters.toml"). 
+#        path_to_array_params = joinpath(splitpath(pathof(CP))[1:end-2]...,"test/array_parameters.toml")
+        path_to_array_params = joinpath(@__DIR__,"array_parameters.toml")
+        # parameter struct of type Float64 (default)
+        param_set = CP.create_parameter_struct(path_to_array_params,
+                                               dict_type="name")
+        # parameter struct of type Float32
+        param_set_f32 = CP.create_parameter_struct(path_to_array_params,
+                                                   dict_type="name",
+                                                   value_type=Float32)
+        
+        # true parameter values (used to check if values are correctly read from
+        # the toml file)
+        true_param_1 = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0]
+        true_param_2 = [0.0, 1.0, 1.0, 2.0, 3.0, 5.0, 8.0, 13.0, 21.0, 34.0]
+        true_param_3 = [9.81, 10.0]
+        true_param_4 = 299792458 
+        true_params = [true_param_1, true_param_2, true_param_3, true_param_4]
+        param_names = ["array_parameter_1", "array_parameter_2",
+                       "gravitational_acceleration", "light_speed"]
+        
+        # Let's assume that parameter_vector_1 and parameter_vector_2 are used
+        # in a module called "Test"
+        mod = "Test"
+        
+        # Get parameter values and add information on the module where the
+        # parameters are used. 
+        for i in range(1, stop=length(true_params))
+            
+            param = CP.get_parameter_values!(param_set, param_names[i], mod)
+            @test param == true_params[i]
+            # Check if the parameter is of the correct type. It should have
+            # the same type as the ParamDict, which is specified by the
+            # `value_type`` argument to `create_parameter_struct`.
+            @test eltype(param) == Float64
+            
+            param_f32 = CP.get_parameter_values!(param_set_f32, param_names[i], mod)
+            @test eltype(param_f32) == Float32
+
         end
         
-        k_found[1] = 0
-    end
-
-    #create a dummy log file listing where CLIMAParameter lives
-    logfilepath = joinpath(@__DIR__,"log_file_test_1.toml")
-    CP.write_log_file(full_parameter_set, logfilepath)
-
-    #read in log file as new parameter file and rerun test.
-    full_parameter_set_from_log = CP.create_parameter_struct(logfilepath,dict_type = "alias")
-    k_found=[0]
-    for (k, v) in full_parameter_set_from_log #iterates over data (by alias) 
-        for mod in module_names
-            k_value = CP.get_parameter_values(full_parameter_set_from_log, k) 
-            if k in CP_parameters[mod]
-                k_found[1] = 1
-                cp_k = getfield(mod, Symbol(k))                 
-                if ~(k in universal_constant_aliases)
-                    @test (k_value ≈ cp_k(param_set_cpp))
-                else #universal parameters have no argument
-                    @test (k_value ≈ cp_k())
-                end
-            end
+        # Get several parameter values (scalar and arrays) at once
+        params = CP.get_parameter_values(param_set, param_names)
+        for j in 1:length(param_names)
+            @test params[j] == true_params[j]
         end
-        if k_found[1] == 0
-            println("on trying alias: ", k)
-            @warn("did not find in any modules")
-        end
-        k_found[1] = 0
-    end
-    
-
-    # Tests to check if file parsing, extracting and logging of parameter
-    # values also works with array-valued parameters
-
-    # Create parameter structs consisting of the parameters contained in the
-    # default parameter file ("parameters.toml") and additional (array valued)
-    # parameters ("array_parameters.toml"). 
-    path_to_array_params = joinpath(splitpath(pathof(CP))[1:end-2]...,"test/array_parameters.toml")
-    # parameter struct of type Float64 (default)
-    param_set = CP.create_parameter_struct(path_to_array_params,
-                                           dict_type="name")
-    # parameter struct of type Float32
-    param_set_f32 = CP.create_parameter_struct(path_to_array_params,
-                                               dict_type="name",
-                                               value_type=Float32)
-
-    # true parameter values (used to check if values are correctly read from
-    # the toml file)
-    true_param_1 = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0]
-    true_param_2 = [0.0, 1.0, 1.0, 2.0, 3.0, 5.0, 8.0, 13.0, 21.0, 34.0]
-    true_param_3 = [9.81, 10.0]
-    true_param_4 = 299792458 
-    true_params = [true_param_1, true_param_2, true_param_3, true_param_4]
-    param_names = ["array_parameter_1", "array_parameter_2",
-                   "gravitational_acceleration", "light_speed"]
-
-    # Let's assume that parameter_vector_1 and parameter_vector_2 are used
-    # in a module called "Test"
-    mod = "Test"
-
-    # Get parameter values and add information on the module where the
-    # parameters are used. 
-    for i in range(1, stop=length(true_params))
-
-        param = CP.get_parameter_values!(param_set, param_names[i], mod)
-        @test param == true_params[i]
-        # Check if the parameter is of the correct type. It should have
-        # the same type as the ParamDict, which is specified by the
-        # `value_type`` argument to `create_parameter_struct`.
-        @test eltype(param) == Float64
-
-        param_f32 = CP.get_parameter_values!(param_set_f32, param_names[i], mod)
-        @test eltype(param_f32) == Float32
-
+        
+        # Write parameters to log file
+        CP.write_log_file(param_set, logfilepath2)
+        
+        # `param_set` and `full_param_set` contain different values for the
+        # `gravitational_acceleration` parameter. The merged parameter set should
+        # contain the value from `param_set`.
+        full_param_set = CP.create_parameter_struct(dict_type="name")
+        merged_param_set = CP.merge_override_default_values(
+            param_set,
+            full_param_set,
+        )
+        grav = CP.get_parameter_values(
+            merged_param_set,
+            "gravitational_acceleration")
+        @test grav == true_param_3
     end
 
-    # Get several parameter values (scalar and arrays) at once
-    params = CP.get_parameter_values(param_set, param_names)
-    for j in 1:length(param_names)
-        @test params[j] == true_params[j]
+    @testset "checks for overrides" begin
+        full_param_set = CP.create_parameter_struct(joinpath(@__DIR__,"override_typos.toml"), dict_type="name")
+        @test_logs (:warn,) CP.log_parameter_information(full_param_set, logfilepath3)
+        @test_throws ErrorException CP.log_parameter_information(full_param_set, logfilepath3, warn_else_error="error")
     end
-    
-    # Write parameters to log file
-    logfilepath = joinpath(@__DIR__, "log_file_test_2.toml")
-    CP.write_log_file(param_set, logfilepath)
 
-    # `param_set` and `full_param_set` contain different values for the
-    # `gravitational_acceleration` parameter. The merged parameter set should
-    # contain the value from `param_set`.
-    full_param_set = CP.create_parameter_struct(dict_type="name")
-    merged_param_set = CP.merge_override_default_values(param_set,
-                                                        full_param_set,
-                                                        )
-    grav = CP.get_parameter_values(merged_param_set,
-                                   "gravitational_acceleration")
-    @test grav == true_param_3
-    
+
 end

--- a/test/uq_parameters.jl
+++ b/test/uq_parameters.jl
@@ -1,0 +1,234 @@
+using Test
+using Distributions
+using Random
+using LinearAlgebra
+
+# import CLIMAParameters
+using CLIMAParameters
+const CP = CLIMAParameters
+
+using EnsembleKalmanProcesses
+using EnsembleKalmanProcesses.Observations
+using EnsembleKalmanProcesses.ParameterDistributions
+const EKP = EnsembleKalmanProcesses
+
+@testset "Parse and write parameter distributions" begin
+
+    # Load parameters
+    toml_path = joinpath(@__DIR__,"uq_test_parameters.toml")
+    param_dict = CP.read_parameters(toml_path)
+
+
+    # True `ParameterDistribution`s. This is what `get_parameter_distribution`
+    # should return
+    target_map = Dict(
+        "uq_param_1" => ParameterDistribution(
+            Parameterized(Normal(2.0, 1.0)),
+            no_constraint(),
+            "uq_param_1"),
+
+        "uq_param_2" => ParameterDistribution(
+            Parameterized(Gamma(5.0, 2.0)),
+            bounded_below(3.0),
+            "uq_param_2"),
+
+        "uq_param_3" => ParameterDistribution(
+            Parameterized(MvNormal(4, 0.1)),
+            [no_constraint(), bounded_below(-1.0),
+            bounded_above(0.4), bounded(-0.1, 0.2)],
+            "uq_param_3"),
+
+        "uq_param_4" => ParameterDistribution(
+            Samples([1.0 3.0 5.0 7.0; 9.0 11.0 13.0 15.0]),
+            [bounded(10.0, 15.0), bounded_below(-1.0)],
+            "uq_param_4"),
+
+        "uq_param_5" => ParameterDistribution(
+            Samples([1.0 3.0; 5.0 7.0; 9.0 11.0; 13.0 15.0]),
+            [no_constraint(), no_constraint(),
+             bounded_below(-2.0), bounded_above(100.0)],
+            "uq_param_5"),
+
+        "uq_param_6" => ParameterDistribution(
+            [Parameterized(Gamma(2.0, 1.0)), Parameterized(Gamma(2.0, 1.0)),
+             Parameterized(Gamma(2.0, 1.0))],
+            [[bounded_above(9.0)], [bounded_above(9.0)], [bounded_above(9.0)]],
+            ["uq_param_6_(1)", "uq_param_6_(2)", "uq_param_6_(3)"]),
+
+        "uq_param_7" => ParameterDistribution(
+            Parameterized(MvNormal(3, 2.0)),
+            [no_constraint(), no_constraint(), no_constraint()],
+            "uq_param_7")
+    )
+
+    # Get all `ParameterDistribution`s. We also add dummy (key, value) pairs
+    # to check if that information gets added correctly when saving the
+    # parameters back to file and re-loading them
+    uq_param_names = CP.get_UQ_parameters(param_dict)
+    descr = " will be learned using CES"
+
+    for param_name in uq_param_names
+        param_dict[param_name]["description"] = param_name * descr
+        pd = CP.get_parameter_distribution(param_dict, param_name)
+        target_pd = target_map[param_name]
+
+        # Check names
+        @test get_name(pd) == get_name(target_pd)
+        # Check distributions
+        @test get_distribution(pd) == get_distribution(target_pd)
+        # Check constraints
+        constraints = get_all_constraints(pd)
+        target_constraints = get_all_constraints(target_pd)
+        @test constraints == target_constraints
+
+    end
+
+    # We can also get a `ParameterDistribution` representing
+    # multiple parameters
+    param_list = ["uq_param_2", "uq_param_4", "uq_param_5"]
+    pd = CP.get_parameter_distribution(param_dict, param_list)
+
+    # Save the parameter dictionary and re-load it. 
+    logfile_path = joinpath(@__DIR__,"log_file_test_uq.toml")
+    CP.write_log_file(param_dict, logfile_path)
+
+    # Read in log file as new parameter file and rerun test.
+    param_dict_from_log = CP.read_parameters(logfile_path)
+    for param_name in uq_param_names
+        pd = CP.get_parameter_distribution(param_dict_from_log, param_name)
+        @test get_distribution(pd) == get_distribution(target_map[param_name])
+        @test param_dict_from_log[param_name]["description"] == param_name*descr
+    end
+
+end
+
+# This test set creates a directory "test_output" in "CLIMAParameters.jl/test"
+# where the new parameteter files resulting from updating an ensemble Kalman
+# ensemble are saved
+@testset "Save parameter ensemble" begin
+
+    # Combine a parameter struct from the parameters defined in
+    # "uq_test_parameters.toml" (the override file) and those defined in
+    # "test_parameters.toml" (the default file)
+    toml_path = joinpath(@__DIR__,"uq_test_parameters.toml")
+    param_dict = CP.read_parameters(toml_path)
+
+    # Extract the UQ parameters from the joint set of the parameters from
+    # param_path and those from uq_param_path
+    uq_param_names = CP.get_UQ_parameters(param_dict)
+
+    # Seed for pseudo-random number generator
+    rng_seed = 42
+    rng = Random.MersenneTwister(rng_seed)
+    
+    # Construct the parameter distribution
+    pd = CP.get_parameter_distribution(param_dict, uq_param_names)
+    slices = batch(pd) # Will need this later to extract parameters
+
+    # ------
+    # Set up an ensemble Kalman process to test writing of parameter ensembles
+    # ------
+
+    # Generate symthetic observations y_obs by evaluating a (completely
+    # contrived) forward map G(u) (where u are the parameters) with the 
+    # the true parameter values u* (which we pretend to know for the
+    # purpose of this example) and adding random observational noise η
+
+    A3 = Array(reshape(range(1, stop=16), 4, 4))
+    A5 = Array(reshape(range(0, stop=1.0, length=16), 4, 4))
+
+    function G(u) # map from R^18 to R^4
+        u_constr = transform_unconstrained_to_constrained(pd, u)
+        value_of = Dict()
+        for (i, param) in enumerate(get_name(pd))
+            value_of[param] = u_constr[slices[i]]
+        end
+        A4 = reshape(
+            [norm(value_of["uq_param_4"]) + value_of["uq_param_6_(1)"][1],
+             norm(value_of["uq_param_6_(2)"]) * value_of["uq_param_6_(3)"][1],
+             value_of["uq_param_2"][1],
+             value_of["uq_param_1"][1]], 4, 1)
+        y = (A3 * value_of["uq_param_3"] + A5 * value_of["uq_param_5"]
+             + norm(value_of["uq_param_4"]) * A4)
+        return dropdims(y, dims=2) 
+    end
+
+    # True parameter values (in constrained space)
+    u1_star = 14.6
+    u2_star = 19.0
+    u3_star = [0.12, -0.05, -0.13, 0.05]
+    u4_star = [12.0, 14.0]
+    u5_star = [10.0, -1.0, 1.5, 10.0]
+    u6_1_star = 1.0
+    u6_2_star = 1.0
+    u6_3_star = 1.0
+    u7_star = 3.0 * ones(3)
+
+    # Synthetic observation
+    A4_star = reshape(
+        [norm(u4_star) + u6_1_star,
+         norm(u6_2_star) * u6_3_star,
+         u2_star,
+         u1_star], 4, 1)
+
+    y_star = A3 * u3_star + A5 * u5_star + norm(u4_star) * A4_star # G(u_star)
+    Γy = 0.05 * I
+    pdf_η = MvNormal(zeros(4), Γy)
+    y_obs = dropdims(y_star, dims=2) .+ rand(pdf_η)
+
+    N_ens = 50 # number of ensemble members
+    N_iter = 1 # number of iterations
+
+    # Generate and save initial paramter ensemble 
+    initial_ensemble = EKP.construct_initial_ensemble(rng, pd, N_ens)
+    save_path = joinpath(@__DIR__, "test_output")
+    save_file = "test_parameters.toml"
+    CP.save_parameter_ensemble(
+        initial_ensemble,
+        pd,
+        param_dict,
+        save_path,
+        save_file,
+        0 # We consider the initial ensemble to be the 0th iteration
+    )
+
+    # Instantiate an ensemble Kalman process
+    eksobj = EKP.EnsembleKalmanProcess(
+        initial_ensemble,
+        y_obs,
+        Γy,
+        Inversion(),
+        rng=rng)
+
+    # EKS iterations
+    for i in 1:N_iter
+        params_i = get_u_final(eksobj)
+        G_n = [G(params_i[:, member_idx]) for member_idx in 1:N_ens]
+        G_ens = hcat(G_n...)
+        EKP.update_ensemble!(eksobj, G_ens)
+
+        # Save updated parameter ensemble
+        CP.save_parameter_ensemble(
+            EKP.get_u_final(eksobj),
+            pd,
+            param_dict,
+            save_path,
+            save_file,
+            i
+        )
+    end
+
+    # Check if all parameter files have been created (we expect there to be
+    # one for each iteration and ensemble member)
+    @test isdir(joinpath(save_path, "iteration_00"))
+    @test isdir(joinpath(save_path, "iteration_01"))
+    subdir_names = CP.generate_subdir_names(N_ens)
+    for i in 1:N_ens
+        subdir_0 = joinpath(save_path, "iteration_00", subdir_names[i])
+        subdir_1 = joinpath(save_path, "iteration_01", subdir_names[i])
+        @test isdir(subdir_0)
+        @test isfile(joinpath(subdir_0, save_file))
+        @test isdir(subdir_1)
+        @test isfile(joinpath(subdir_1, save_file))
+    end
+end

--- a/test/uq_test_parameters.toml
+++ b/test/uq_test_parameters.toml
@@ -1,0 +1,68 @@
+# The seven parameters below are to be used for calibration / uncertainty 
+# quantification
+[uq_param_1]
+prior = "Parameterized(Normal(2.0, 1.0))"
+constraint = "no_constraint()"
+
+[uq_param_2]
+prior = "Parameterized(Gamma(5.0, 2.0))"
+constraint = "bounded_below(3.0)"
+
+[uq_param_3]
+prior = "Parameterized(MvNormal(4, 0.1))"
+constraint = "[no_constraint(), bounded_below(-1.0), bounded_above(0.4), bounded(-0.1,0.2)]"
+
+[uq_param_4]
+prior = "Samples([1.0 3.0 5.0 7.0; 9.0 11.0 13.0 15.0])"
+constraint = "[bounded(10.0, 15.0), bounded_below(-1.0)]"
+
+[uq_param_5]
+prior = "Samples([1.0 3.0; 5.0 7.0; 9.0 11.0; 13.0 15.0])"
+constraint = "[no_constraint(), no_constraint(), bounded_below(-2.0), bounded_above(100.0)]"
+
+# Convenience notation for arrays of parameters that all have the same prior 
+# distribution and constraints. 
+# `repeat([prior], n_dims)` will construct `n_dims` prior distribution. 
+# Similarly,  `repeat([constraint], n_dims)` will construct `n_dims` 
+# constraints. 
+# The resulting `n_dims` parameters will automatically be attaching numbers, 
+# e.g., "uq_param_6_(1)", "uq_param_6_(2)", etc.
+[uq_param_6]
+prior = "repeat([Parameterized(Gamma(2.0, 1.0))], 3)"
+constraint = "repeat([[bounded_above(9.0)]], 3)"
+
+# A repeated constraint can also be combined with a multivariate distribution.
+[uq_param_7]
+prior = "Parameterized(MvNormal(3, 2.0))"
+constraint = "repeat([no_constraint()], 3)"
+
+
+# The six parameters below are "regular" parameters, as indicated  by the 
+# absence of a key "prior", or by a key "prior" that is set to "fixed"
+[mean_sea_level_pressure]
+alias = "MSLP"
+value = 101325
+
+[gas_constant]
+alias = "gas_constant"
+value = 8.3144598
+
+[light_speed]
+alias = "light_speed"
+value = 299792458
+
+[planck_constant]
+alias = "h_Planck"
+value = 6.626e-34
+
+[avogadro_constant]
+alias = "avogad"
+value = 6.02214076e23
+
+# This parameter is not interpreted as a UQ parameter because its prior is set 
+# to "fixed"
+[already_calibrated_param]
+prior = "fixed"
+constraint = "bounded_above(5.0)"
+value = "0.64"
+

--- a/test/uq_test_parameters.toml
+++ b/test/uq_test_parameters.toml
@@ -1,44 +1,47 @@
-# The seven parameters below are to be used for calibration / uncertainty 
+# The eight parameters below are to be used for calibration / uncertainty 
 # quantification
 [uq_param_1]
-prior = "Parameterized(Normal(2.0, 1.0))"
+prior = "Parameterized(Normal(-100.0, 20.0))"
 constraint = "no_constraint()"
+L1 = 1.5
 
 [uq_param_2]
 prior = "Parameterized(Gamma(5.0, 2.0))"
-constraint = "bounded_below(3.0)"
+constraint = "bounded_below(6.0)"
 
 [uq_param_3]
-prior = "Parameterized(MvNormal(4, 0.1))"
-constraint = "[no_constraint(), bounded_below(-1.0), bounded_above(0.4), bounded(-0.1,0.2)]"
+prior = "Parameterized(MvNormal(4, 10.0))"
+constraint = "[no_constraint(), bounded_below(-100.0), bounded_above(10.0), bounded(-42.0, 42.0)]"
+L2 = 1.1
 
 [uq_param_4]
-prior = "Samples([1.0 3.0 5.0 7.0; 9.0 11.0 13.0 15.0])"
-constraint = "[bounded(10.0, 15.0), bounded_below(-1.0)]"
+prior = "Samples([5.0 3.2 4.8 3.6; -5.4 -4.7 -3.9 -4.5])"
+constraint = "[bounded(0.0, 15.0), bounded_below(-10.0)]"
 
 [uq_param_5]
 prior = "Samples([1.0 3.0; 5.0 7.0; 9.0 11.0; 13.0 15.0])"
-constraint = "[no_constraint(), no_constraint(), bounded_below(-2.0), bounded_above(100.0)]"
+constraint = "[no_constraint(), no_constraint(), bounded_below(-2.0), bounded_above(20.0)]"
 
-# Convenience notation for arrays of parameters that all have the same prior 
-# distribution and constraints. 
-# `repeat([prior], n_dims)` will construct `n_dims` prior distribution. 
-# Similarly,  `repeat([constraint], n_dims)` will construct `n_dims` 
-# constraints. 
-# The resulting `n_dims` parameters will automatically be attaching numbers, 
-# e.g., "uq_param_6_(1)", "uq_param_6_(2)", etc.
+# Convenience notation for arrays of parameters 
+# `VectorOfParameterized(repeat([<prior>], n)` will construct `n` prior distributions. 
+# Similarly, `repeat([<constraint>], n)` will construct `n` constraints. 
 [uq_param_6]
-prior = "repeat([Parameterized(Gamma(2.0, 1.0))], 3)"
-constraint = "repeat([[bounded_above(9.0)]], 3)"
+prior = "VectorOfParameterized(repeat([Gamma(2.0, 3.0)], 3))"
+constraint = "repeat([bounded_above(9.0)], 3)"
 
 # A repeated constraint can also be combined with a multivariate distribution.
 [uq_param_7]
 prior = "Parameterized(MvNormal(3, 2.0))"
 constraint = "repeat([no_constraint()], 3)"
 
+# Instead of a `repeat` expression, priors and constraints can also be defined by an 
+# array that lists each element explicitly
+[uq_param_8]
+prior = "VectorOfParameterized([Gamma(2.0, 3.0), LogNormal(0.1, 0.1), Normal(0.0, 10.0)])"
+constraint = "[no_constraint(), no_constraint(), bounded_below(-5.0)]"
 
-# The six parameters below are "regular" parameters, as indicated  by the 
-# absence of a key "prior", or by a key "prior" that is set to "fixed"
+# The six parameters below are interpreted as "regular" (non-UQ) parameters, as they
+# they either have no key "prior", or a key "prior" that is set to "fixed"
 [mean_sea_level_pressure]
 alias = "MSLP"
 value = 101325


### PR DESCRIPTION
## Purpose
Generalize away from alias => `::Dict`. Also we can now write **re-readable** log files

## In this PR
- Documentation! See  the latest documentor build below.
- New wrapper ```ParamDict{FT}```around dictionary read from toml. Currently parametric on one type of all the values, provided when it is built (default is `Float64`). Construction:
```julia
create_parameter_struct(override_filepath, default_filepath; dict_type="alias",value_type=Float64) # builds with override and custom default provided
create_parameter_struct(override_filepath ; dict_type="alias",value_type=Float64) # builds, overriding the default from CLIMAParameters
create_parameter_struct(; dict_type="alias",value_type=Float64) # builds using only default in CLIMAParameters
```
- Automated parameter logging on reading parameter values: (can do multiple parameters at once). At the call of this function, the type is enforced on the return values.
```julia 
get_parameter_values!(pd::ParamDict, names, component; log_component=true) #logs component in pd
get_parameter_values(pd::ParamDict,names) # no logging in pd
```
- writing the re-readable log file in `log_parameter_information(pd::ParamDict,filepath)`. Example parameter tested in `CloudMicrophysics.jl`:
```toml
# initial parameter file
[molar_mass_water]
alias = "molmass_water"
value = 0.01801528
type = "float"
```
In this test, a copy of the parameters was created and stored in (1) Thermodynamics, (2) the general CloudMicrophysics, and (3) the specific 1-moment-based Microphysics scheme. Indeed the logfile shows this information below
```toml
# log file
[molar_mass_water]
alias = "molmass_water"
value = 0.01801528
type = "float"
used_in = ["Thermodynamics", "CloudMicrophysicsParameters", "Microphysics_1M_Parameters"]
```
The `log_parameter_information(pd::ParamDict,filepath; warn_else_error="warn")` will also throw warnings if a parameter is in the override file, but unused in the simulation. This works as parameters from the override file are checked for whether they have gained a "used_in" tag, if not found then an this is logged as a warning or error
- From PR #65, reading of array-type parameters
- From PR #68, reading and writing for calibration tools
### TODO
- still using alias based structs
- still based on float, and array-of-float parameters
