### PR TITLE
add the exponent for the assumed phase partition function

### DIFF
--- a/docs/src/API.md
+++ b/docs/src/API.md
@@ -47,6 +47,7 @@ Planet.T_freeze
 Planet.T_min
 Planet.T_max
 Planet.T_icenuc
+Planet.pow_icenuc
 Planet.T_triple
 Planet.T_0
 Planet.LH_v0

--- a/src/Planet/Planet.jl
+++ b/src/Planet/Planet.jl
@@ -25,6 +25,7 @@ export molmass_dryair,
     T_min,
     T_max,
     T_icenuc,
+    pow_icenuc,
     T_triple,
     T_0,
     LH_v0,
@@ -99,6 +100,8 @@ function T_min end
 function T_max end
 """ Homogeneous nucleation temperature (K) """
 function T_icenuc end
+""" The assumed phase partition function power (-) """
+function pow_icenuc end
 """ Triple point temperature (K) """
 function T_triple end
 """ Reference temperature (K) """

--- a/src/Planet/planet_parameters.jl
+++ b/src/Planet/planet_parameters.jl
@@ -23,6 +23,7 @@ Planet.T_freeze(ps::AbstractEarthParameterSet)              = 273.15
 Planet.T_min(ps::AbstractEarthParameterSet)                 = 150.0
 Planet.T_max(ps::AbstractEarthParameterSet)                 = 1000.0
 Planet.T_icenuc(ps::AbstractEarthParameterSet)              = 233.00
+Planet.pow_icenuc(ps::AbstractEarthParameterSet)            = 1
 Planet.T_triple(ps::AbstractEarthParameterSet)              = 273.16
 Planet.T_0(ps::AbstractEarthParameterSet)                   = Planet.T_triple(ps)
 Planet.LH_v0(ps::AbstractEarthParameterSet)                 = 2.5008e6

--- a/test/planet.jl
+++ b/test/planet.jl
@@ -28,6 +28,7 @@ using CLIMAParameters.Planet
   @test !isnan(T_min(ps))
   @test !isnan(T_max(ps))
   @test !isnan(T_icenuc(ps))
+  @test !isnan(pow_icenuc(ps))
   @test !isnan(press_triple(ps))
   @test !isnan(surface_tension_coeff(ps))
 


### PR DESCRIPTION
I want to be able to use a phase partition function similar to the one in PyCLES:

(T - T_icenuc / T_freeze - T_icenuc)^pow_icenuc

The T_icenuc and T_freeze are already defined. This PR adds the exponent parameter