### PR TITLE
bump version

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CLIMAParameters"
 uuid = "6eacf6c3-8458-43b9-ae03-caf5306d3d53"
 authors = ["Charles Kawczynski <kawczynski.charles@gmail.com>"]
-version = "0.4.0"
+version = "0.4.1"
 
 [deps]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"


### PR DESCRIPTION
I want to make a new release so that I can use my new `pow_icenuc` parameter. 

This is not a breaking change for CLIMAParameters. But it will be a breaking change for TC.jl once I start using the new parameter. So I'm thinking I should bump 0.4 -> 0.5?