### PR TITLE
Add `required_kw_fieldnames`

### DIFF
--- a/docs/src/API.md
+++ b/docs/src/API.md
@@ -16,6 +16,7 @@ AliasParamDict
 
 ### User facing functions:
 ```@docs
+required_kw_fieldnames
 create_parameter_struct
 get_parameter_values!
 get_parameter_values

--- a/src/CLIMAParameters.jl
+++ b/src/CLIMAParameters.jl
@@ -4,6 +4,7 @@ export AbstractParameterSet
 export AbstractEarthParameterSet
 
 include("file_parsing.jl")
+include("utils.jl")
 include("types.jl")
 include("UniversalConstants.jl")
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,0 +1,53 @@
+"""
+    required_kw_fieldnames(::Type, valid_elem = 1)
+
+Returns a tuple of symbols that are required
+(do not have default values) for the _keyword_
+constructor for type `T`.
+
+This method is generally intended for types that
+fields that all have the same element type.
+
+If the element type is restricted, `valid_elem`
+may be passed, however, for following constructor
+must be allowed:
+
+`T(;Pair.(fieldnames(T), (valid_elem))...)`
+"""
+function required_kw_fieldnames(::Type{T}, valid_elem = 1) where {T}
+    all_fieldnames = fieldnames(T)
+    rkfn = Symbol[]
+    isempty(all_fieldnames) && return NTuple{0, Symbol}()
+
+    @assert hasmethod(T, Tuple{}, all_fieldnames) string(
+        "Constructor `$T` must be callable with ",
+        "`$T(;Pair.(fieldnames($T), $(valid_elem))...)`",
+        "Perhaps $T's definition is missing `Base.@kwdef`.",
+    )
+    try
+        T(; Pair.(all_fieldnames, valid_elem)...)
+    catch err
+        @error string(
+            "\nFailed to construct `$T` with ",
+            "`$T(;Pair.(fieldnames($T), valid_elem)...)`, where\n",
+            "valid_elem = $valid_elem\n",
+            "typeof(valid_elem) = $(typeof(valid_elem))\n",
+        )
+        rethrow(err)
+    end
+
+    for fn in all_fieldnames
+        all_but_fn = map(filter(x -> x ≠ fn, all_fieldnames)) do fn′
+            Pair(fn′, valid_elem)
+        end
+        callable_method = try
+            T(; all_but_fn...)
+            true
+        catch
+            false
+        end
+        callable_method && continue
+        push!(rkfn, fn)
+    end
+    return tuple(rkfn...)
+end

--- a/test/required_kw_fieldnames.jl
+++ b/test/required_kw_fieldnames.jl
@@ -1,0 +1,51 @@
+using Test
+import CLIMAParameters
+const CP = CLIMAParameters
+
+@testset "Singleton" begin
+    Base.@kwdef struct Singleton end
+    @test CP.required_kw_fieldnames(Singleton) == NTuple{0, Symbol}()
+end
+
+@testset "ParameterizedSingleton" begin
+    Base.@kwdef struct ParameterizedSingleton{T} end
+    @test CP.required_kw_fieldnames(ParameterizedSingleton) ==
+          NTuple{0, Symbol}()
+end
+
+@testset "Parameterized struct" begin
+    Base.@kwdef struct Foo{T}
+        a::T
+        b::T = a
+        c::T
+        d::T = b + a
+    end
+    @test CP.required_kw_fieldnames(Foo) == (:a, :c)
+end
+
+@testset "Missing Base.@kwdef" begin
+    struct Bar{T}
+        a::T
+        b::T
+        c::T
+        d::T
+    end
+    @test_throws AssertionError(
+        string(
+            "Constructor `Bar` must be callable with ",
+            "`Bar(;Pair.(fieldnames(Bar), 1)...)`Perhaps Bar's ",
+            "definition is missing `Base.@kwdef`.",
+        ),
+    ) CP.required_kw_fieldnames(Bar)
+
+end
+
+@testset "Bad valid_elem" begin
+    Base.@kwdef struct Baz{T <: AbstractFloat}
+        a::T
+        b::T
+        c::T
+        d::T
+    end
+    @test_throws MethodError CP.required_kw_fieldnames(Baz, Real(1))
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
 include("toml_consistency.jl")
 include("param_boxes.jl")
+include("required_kw_fieldnames.jl")
 
 include("old/planet.jl")
 include("old/subgrid_scale.jl")


### PR DESCRIPTION
This PR adds a new function, `required_kw_fieldnames`, which returns a tuple of the fieldnames required (without default arguments) in the keyword constructor for the given type.

I think we can use this to trim down the aliases list in all the repos.

What's implemented is not really efficient, but this is only done once per struct and will help trim down maintaining lists of parameters. In theory this method could be added to julia Base, and `@kwdef` could determine this list more efficiently at macro expansion time.

I've updated the `ParamBox` example to use this as a demo. It's almost looking generic enough that we could make a generic constructor, but I think it's compact enough with this that users can work with the raw components and we can further abstract later if needed. This new function already stretches things as it is (i.e., requiring certain constructor types for the boxes).