### PR TITLE
Improve names struct -> dict

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -3,7 +3,7 @@ using CLIMAParameters, Documenter
 pages = Any[
     "Home" => "index.md",
     "TOML file interface" => "toml.md",
-    "Parameter structures" => "parameter_structs.md",
+    "TOML dicts" => "toml_dicts.md",
     "API" => "API.md",
 ]
 

--- a/docs/src/API.md
+++ b/docs/src/API.md
@@ -4,10 +4,10 @@
 CurrentModule = CLIMAParameters
 ```
 
-## Parameter struct
+## Parameter dictionaries
 
 ```@docs
-AbstractParamDict
+AbstractTOMLDict
 ParamDict
 AliasParamDict
 ```
@@ -16,7 +16,7 @@ AliasParamDict
 
 ### User facing functions:
 ```@docs
-create_parameter_struct
+create_toml_dict
 get_parameter_values!
 get_parameter_values
 float_type

--- a/docs/src/toml.md
+++ b/docs/src/toml.md
@@ -67,9 +67,9 @@ Here, the `value` field has been overwritten by the experiment value.
 ### Loading from file
 We provide the following methods to load parameters from file
 ```julia
-create_parameter_struct(Float64;override_filepath, default_filepath, dict_type="alias")
-create_parameter_struct(Float64;override_filepath ; dict_type="alias")
-create_parameter_struct(Float64; dict_type="name")
+create_toml_dict(Float64;override_filepath, default_filepath, dict_type="alias")
+create_toml_dict(Float64;override_filepath ; dict_type="alias")
+create_toml_dict(Float64; dict_type="name")
 ```
 - The `dict_type = "name"` or `"alias"` determines the method of lookup of parameters (by `name` or by `alias` attributes).
 - The `Float64` (or `Float32`) defines the requested precision of the returned parameters.
@@ -78,30 +78,30 @@ Typical usage involves passing the local parameter file
 ```julia
 import CLIMAParameters
 local_exp_file = joinpath(@__DIR__,"local_exp_parameters.toml")
-parameter_struct = CLIMAParameters.create_parameter_struct(;local_exp_file)
+toml_dict = CLIMAParameters.create_toml_dict(;local_exp_file)
 ```
 If no file is passed it will use only the defaults from `CLIMAParameters.jl` (causing errors if required parameters are not within this list).
 
 !!! note
     Currently we search by the `alias` field (`dict_type="alias"` by default), so all parameters need an `alias` field, if in doubt, set alias and name to match the current code name convention.
 
-The parameter struct is then used to build the codebase (see relevant Docs page).
+The parameter dict is then used to build the codebase (see relevant Docs page).
 
 ### Logging parameters
 
 Once the CliMA components are built, it is important to log the parameters. We provide the following methodd
 ```julia
-log_parameter_information(parameter_struct, filepath; strict=false)
+log_parameter_information(toml_dict, filepath; strict=false)
 ```
 
 Typical usage will be after building components and before running
 ```julia
 import Thermodynamics
-therm_params = Thermodynamics.ThermodynamicsParameters(parameter_struct)
+therm_params = Thermodynamics.ThermodynamicsParameters(toml_dict)
 #... build(thermodynamics model,therm_params)
 
 log_file = joinpath(@__DIR__,"parameter_log.toml")
-CLIMAParameters.log_parameter_information(parameter_struct,log_file)
+CLIMAParameters.log_parameter_information(toml_dict,log_file)
 
 # ... run(thermodynamics_model)
 ```

--- a/docs/src/toml_dicts.md
+++ b/docs/src/toml_dicts.md
@@ -1,16 +1,16 @@
-# Parameter Structures
+# Parameter Dictionaries
 
 Parameters are stored in objects that reflect the model component construction. Definitions should be inserted into the model component source code.
 
-## An example from `Thermodynamics.jl` 
+## An example from `Thermodynamics.jl`
 
 ### In the user-facing driver file
 ```julia
 import CLIMAParameters
 import Thermodynamics
 
-parameter_struct = CLIMAParameters.create_parameter_struct(;dict_type="alias") 
-thermo_params = Thermodynamics.ThermodynamicsParameters(parameter_struct)
+toml_dict = CLIMAParameters.create_toml_dict(;dict_type="alias")
+thermo_params = Thermodynamics.ThermodynamicsParameters(toml_dict)
 ```
 
 ### In the source code for `Thermodynamics.jl`
@@ -29,13 +29,13 @@ end
 
 The constructor is as follows
 ```julia
-function ThermodynamicsParameters(parameter_struct)
+function ThermodynamicsParameters(toml_dict)
 
     # Used in thermodynamics, from parameter file
     aliases = [ ..., "gas_constant", "molmass_dryair"]
 
     param_pairs = CLIMAParameters.get_parameter_values!(
-        param_struct,
+        toml_dict,
         aliases,
         "Thermodynamics",
     )
@@ -44,14 +44,14 @@ function ThermodynamicsParameters(parameter_struct)
     # derived parameters from parameter file
     R_d = nt.gas_constant / nt.molmass_dryair
 
-    FT = CP.float_type(param_struct)
+    FT = CP.float_type(toml_dict)
     return ThermodynamicsParameters{FT}(; nt..., R_d)
 end
 ```
 
-- The constructor takes in a `parameter_struct` produced from reading the TOML file.
+- The constructor takes in a `toml_dict` produced from reading the TOML file.
 - We list the aliases of parameters required by `Thermodynamics.jl`.
-- We obtain parameters (in the form of a list of (alias,value) Pairs) from `get_parameter_values!(parameter_struct,aliases,component_name)` The `component_name` is a string used for the parameter log.
+- We obtain parameters (in the form of a list of (alias,value) Pairs) from `get_parameter_values!(toml_dict,aliases,component_name)` The `component_name` is a string used for the parameter log.
 - We convert to namedtuple for ease of extraction.
 - We create any `derived parameters` i.e. commonly used simple functions of parameters that are treated as parameters. Here we create the dry air gas constant `R_d`.
 - We return the `ThermodynamicsParameters{FT}`, where FT is an enforced float type (e.g. single or double precision).
@@ -69,15 +69,15 @@ import Thermodynamics
 import CloudMicrophysics
 
 #load defaults
-parameter_struct = CLIMAParameters.create_parameter_struct(; dict_type="alias")
+toml_dict = CLIMAParameters.create_toml_dict(; dict_type="alias")
 
 #build the low level parameter set
-param_therm = Thermodynamics.ThermodynamicsParameters(parameter_struct)
-param_0M = CloudMicrophysics.Microphysics_0M_Parameters(parameter_struct)
+param_therm = Thermodynamics.ThermodynamicsParameters(toml_dict)
+param_0M = CloudMicrophysics.Microphysics_0M_Parameters(toml_dict)
 
 #build the hierarchical parameter set
 parameter_set = CloudMicrophysics.CloudMicrophysicsParameters(
-    parameter_struct,
+    toml_dict,
     param_0M,
     param_therm
 )
@@ -112,7 +112,7 @@ end
 
 
 function CloudMicrophysicsParameters(
-    parameter_struct,
+    toml_dict,
     MPS::AMPS,
     TPS::ThermodynamicsParameters{FT},
 ) where {FT, AMPS <: AbstractMicrophysicsParameters}
@@ -120,7 +120,7 @@ function CloudMicrophysicsParameters(
     aliases = [ "K_therm", ... ]
 
     param_pairs  = CLIMAParameters.get_parameter_values!(
-        parameter_struct,
+        toml_dict,
         aliases,
         "CloudMicrophysics",
     )
@@ -128,7 +128,7 @@ function CloudMicrophysicsParameters(
     nt = (; param_pairs...)
     #derived parameters
     ...
-    FT = CP.float_type(parameter_struct)
+    FT = CP.float_type(toml_dict)
 
     return CloudMicrophysicsParameters{FT, AMPS}(;
             nt...,
@@ -151,7 +151,7 @@ function example_cloudmicrophysics_func(param_set::CloudMicrophysicsParameters,.
     ...
 end
 ```
-When calling functions from dependent packages, simply pass the relevant lower_level parameter struct
+When calling functions from dependent packages, simply pass the relevant lower_level parameter dict
 ```julia
 function example_cloudmicrophysics_func(param_set::CloudMicrophysicsParameters,...)
     thermo_output = Thermodynamics.thermo_function(param_set.TPS,...)

--- a/test/param_boxes.jl
+++ b/test/param_boxes.jl
@@ -10,14 +10,14 @@ Base.@kwdef struct ParameterBox{FT}
     R_d::FT = gas_constant / molmass_dryair
 end
 
-function ParameterBox(param_struct::CP.AbstractParamDict)
+function ParameterBox(toml_dict::CP.AbstractTOMLDict)
 
     aliases = ["molmass_dryair", "gas_constant", "new_parameter"]
 
-    params = CP.get_parameter_values!(param_struct, aliases, "ParameterBox")
+    params = CP.get_parameter_values!(toml_dict, aliases, "ParameterBox")
     # Returns an array of `Pair`s for all given `aliases`
 
-    FT = CP.float_type(param_struct)
+    FT = CP.float_type(toml_dict)
     return ParameterBox{FT}(; params...)
 end
 
@@ -26,22 +26,19 @@ end
 
     # [1.] read from file
     toml_file = joinpath(@__DIR__, "toml", "parambox.toml")
-    param_struct = CP.create_parameter_struct(
+    toml_dict = CP.create_toml_dict(
         Float64;
         override_file = toml_file,
         dict_type = "alias",
     )
 
     # [2.] build
-    param_set = ParameterBox(param_struct)
+    param_set = ParameterBox(toml_dict)
 
     # [3.] log & checks(with warning)
     mktempdir(@__DIR__) do path
         logfilepath = joinpath(path, "logfilepath.toml")
-        @test_logs (:warn,) CP.log_parameter_information(
-            param_struct,
-            logfilepath,
-        )
+        @test_logs (:warn,) CP.log_parameter_information(toml_dict, logfilepath)
     end
 
     # [4.] use

--- a/test/toml_consistency.jl
+++ b/test/toml_consistency.jl
@@ -5,7 +5,7 @@ import CLIMAParameters
 const CP = CLIMAParameters
 
 # read parameters needed for tests
-full_parameter_set = CP.create_parameter_struct(Float64; dict_type = "alias")
+full_parameter_set = CP.create_toml_dict(Float64; dict_type = "alias")
 
 const CPP = CP.Planet
 struct EarthParameterSet <: CP.AbstractEarthParameterSet end
@@ -40,7 +40,7 @@ logfilepath1 = joinpath(@__DIR__, "toml", "log_file_test_1.toml")
 @testset "parameter file interface tests" begin
 
     @testset "load with name or alias" begin
-        @test_throws AssertionError CP.create_parameter_struct(
+        @test_throws AssertionError CP.create_toml_dict(
             Float64;
             dict_type = "not name or alias",
         )
@@ -92,7 +92,7 @@ logfilepath1 = joinpath(@__DIR__, "toml", "log_file_test_1.toml")
 
 
         #read in log file as new parameter file and rerun test.
-        full_parameter_set_from_log = CP.create_parameter_struct(
+        full_parameter_set_from_log = CP.create_toml_dict(
             Float64;
             override_file = logfilepath1,
             dict_type = "alias",
@@ -124,19 +124,19 @@ logfilepath1 = joinpath(@__DIR__, "toml", "log_file_test_1.toml")
         # Tests to check if file parsing, extracting and logging of parameter
         # values also works with array-valued parameters
 
-        # Create parameter structs consisting of the parameters contained in the
+        # Create parameter dict consisting of the parameters contained in the
         # default parameter file ("parameters.toml") and additional (array valued)
         # parameters ("array_parameters.toml").
         path_to_array_params =
             joinpath(@__DIR__, "toml", "array_parameters.toml")
         # parameter struct of type Float64 (default)
-        param_set = CP.create_parameter_struct(
+        toml_dict = CP.create_toml_dict(
             Float64;
             override_file = path_to_array_params,
             dict_type = "name",
         )
         # parameter struct of type Float32
-        param_set_f32 = CP.create_parameter_struct(
+        toml_dict_f32 = CP.create_toml_dict(
             Float32;
             override_file = path_to_array_params,
             dict_type = "name",
@@ -165,23 +165,23 @@ logfilepath1 = joinpath(@__DIR__, "toml", "log_file_test_1.toml")
         for i in range(1, stop = length(true_params))
 
             param_pair =
-                CP.get_parameter_values!(param_set, param_names[i], mod)
+                CP.get_parameter_values!(toml_dict, param_names[i], mod)
             param = last(param_pair)
             @test param == true_params[i]
             # Check if the parameter is of the correct type. It should have
             # the same type as the ParamDict, which is specified by the
-            # `float_type` argument to `create_parameter_struct`.
+            # `float_type` argument to `create_toml_dict`.
             @test eltype(param) == Float64
 
             param_f32_pair =
-                CP.get_parameter_values!(param_set_f32, param_names[i], mod)
+                CP.get_parameter_values!(toml_dict_f32, param_names[i], mod)
             param_f32 = last(param_f32_pair)
             @test eltype(param_f32) == Float32
 
         end
 
         # Get several parameter values (scalar and arrays) at once
-        params = CP.get_parameter_values(param_set, param_names)
+        params = CP.get_parameter_values(toml_dict, param_names)
         for j in 1:length(param_names)
             param_val = last(params[j])
             @test param_val == true_params[j]
@@ -190,15 +190,15 @@ logfilepath1 = joinpath(@__DIR__, "toml", "log_file_test_1.toml")
         # Write parameters to log file
         mktempdir(@__DIR__) do path
             logfilepath2 = joinpath(path, "log_file_test_2.toml")
-            CP.write_log_file(param_set, logfilepath2)
+            CP.write_log_file(toml_dict, logfilepath2)
         end
 
-        # `param_set` and `full_param_set` contain different values for the
+        # `toml_dict` and `full_param_set` contain different values for the
         # `gravitational_acceleration` parameter. The merged parameter set should
-        # contain the value from `param_set`.
-        full_param_set = CP.create_parameter_struct(Float64; dict_type = "name")
+        # contain the value from `toml_dict`.
+        full_param_set = CP.create_toml_dict(Float64; dict_type = "name")
         merged_param_set =
-            CP.merge_override_default_values(param_set, full_param_set)
+            CP.merge_override_default_values(toml_dict, full_param_set)
         grav_pair = CP.get_parameter_values(
             merged_param_set,
             "gravitational_acceleration",
@@ -208,7 +208,7 @@ logfilepath1 = joinpath(@__DIR__, "toml", "log_file_test_1.toml")
     end
 
     @testset "checks for overrides" begin
-        full_param_set = CP.create_parameter_struct(
+        full_param_set = CP.create_toml_dict(
             Float64;
             override_file = joinpath(@__DIR__, "toml", "override_typos.toml"),
             dict_type = "name",


### PR DESCRIPTION
Parameter struct I think is a bit less informative than parameter dict, since it's really just a wrapper around a dict. This PR changes the name to use `dict` over `struct`.

It's probably better that we do this now before spreading to other repos.

I think this will also help differentiate the param dict vs the param "box", which is also a struct but does not necessarily behave like a dict.