### PR TITLE
Store alias-to-name map for fast alias getindex

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CLIMAParameters"
 uuid = "6eacf6c3-8458-43b9-ae03-caf5306d3d53"
 authors = ["Climate Modeling Alliance"]
-version = "0.5.2"
+version = "0.6.0"
 
 [deps]
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"

--- a/src/file_parsing.jl
+++ b/src/file_parsing.jl
@@ -60,7 +60,19 @@ struct AliasParamDict{FT} <: AbstractTOMLDict{FT}
     data::Dict
     "either a nothing, or a dictionary representing an override parameter TOML file"
     override_dict::Union{Nothing, Dict}
+    "Alias->name map"
+    alias_to_name_map::Dict
+    function AliasParamDict{FT}(
+        data::Dict,
+        override_dict::Union{Nothing, Dict},
+    ) where {FT}
+        alias_to_name_map = Dict(map(collect(keys(data))) do key
+            Pair(data[key]["alias"], key)
+        end)
+        return new{FT}(data, override_dict, alias_to_name_map)
+    end
 end
+
 
 """
     float_type(::AbstractTOMLDict)
@@ -90,6 +102,9 @@ end
 Base.iterate(pd::ParamDict, state) = Base.iterate(pd.data, state)
 Base.iterate(pd::ParamDict) = Base.iterate(pd.data)
 
+Base.getindex(pd::ParamDict, i) = getindex(pd.data, i)
+Base.getindex(pd::AliasParamDict, i) =
+    getindex(pd.data, pd.alias_to_name_map[i])
 
 """
     log_component!(pd::AbstractTOMLDict, names, component)


### PR DESCRIPTION
This PR adds a `alias_to_name_map` to `AliasParamDict` so that we can easily support `getindex` so that these dicts behave like ordinary dicts:

```julia
Base.getindex(pd::ParamDict, i) = getindex(pd.data, i)
Base.getindex(pd::AliasParamDict, i) =
    getindex(pd.data, pd.alias_to_name_map[i])
```

Peeled off from #79.

This PR also bumps the version for a new release.