### PR TITLE
Add bool parsing, corresponding unittests and docs

### DIFF
--- a/docs/src/toml.md
+++ b/docs/src/toml.md
@@ -15,7 +15,7 @@ A parameter is determined by its unique name. It has possible attributes
 6. `transformation`
 
 !!! warn
-    Currently we only support `float` and `array{float}` types. (option-type flags and string switches are not considered CLIMAParameters.)
+    Currently we support `Type` and `array{Type}` for the following Types: `float`, `integer`, `string` and `bool`.
 
 ### Minimal parameter requirement to run in CliMA
 

--- a/src/file_parsing.jl
+++ b/src/file_parsing.jl
@@ -159,6 +159,8 @@ function _get_typed_value(
         return Int(val)
     elseif valtype == "string"
         return String(val)
+    elseif valtype == "bool"
+        return Bool(val)
     else
         error(
             "For parameter with identifier: \"",
@@ -166,7 +168,7 @@ function _get_typed_value(
             "\", the attribute: type = \"",
             valtype,
             "\", is not recognised, ",
-            "\n please select from: type = \"string\", \"float\", or \"integer\" ",
+            "\n please select from: type = \"string\", \"float\", \"integer\", or \"bool\"",
         )
     end
 end
@@ -281,7 +283,7 @@ function check_override_parameter_usage(
         @warn(
             string(
                 "Keys are present in parameter file but not used",
-                "in the simulation. \n Typically this is due to",
+                "in the simulation. \n Typically this is due to ",
                 "a mismatch in parameter name in toml and in source.",
                 "Offending keys: $(unused_override_keys)",
             )

--- a/test/toml/typed_parameters.toml
+++ b/test/toml/typed_parameters.toml
@@ -23,6 +23,11 @@ alias = "ft_array"
 value = [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]
 type = "float"
 
+[bool_param]
+alias = "bool"
+value = true
+type = "bool"
+
 [untyped_param]
 alias = "untyped"
 value = "i_am_of_also_string_type"

--- a/test/types_from_file.jl
+++ b/test/types_from_file.jl
@@ -28,6 +28,7 @@ path_to_params = joinpath(@__DIR__, "toml", "typed_parameters.toml")
         "string_array_param",
         "untyped_param",
         "ft_array_param",
+        "bool_param",
         "light_speed",
     ]
 


### PR DESCRIPTION
Adding Bool support to `file_parsing.jl`, as well as corresponding unit test and updated TOML documentation. Requested by @odunbar