### PR TITLE
Add function to merge multiple TOML files

### DIFF
--- a/docs/src/API.md
+++ b/docs/src/API.md
@@ -22,4 +22,5 @@ get_parameter_values
 float_type
 log_parameter_information
 write_log_file
+merge_toml_files
 ```

--- a/src/CLIMAParameters.jl
+++ b/src/CLIMAParameters.jl
@@ -11,7 +11,8 @@ export float_type,
     get_parameter_values,
     write_log_file,
     log_parameter_information,
-    create_toml_dict
+    create_toml_dict,
+    merge_toml_files
 
 include("file_parsing.jl")
 

--- a/test/param_boxes.jl
+++ b/test/param_boxes.jl
@@ -1,8 +1,8 @@
 module ParameterBoxes
 
 using Test
-import CLIMAParameters
-const CP = CLIMAParameters
+
+import CLIMAParameters as CP
 
 Base.@kwdef struct ParameterBox{FT}
     molmass_dryair::FT

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,3 +1,4 @@
 include("toml_consistency.jl")
 include("param_boxes.jl")
 include("types_from_file.jl")
+include("test_merge.jl")

--- a/test/test_merge.jl
+++ b/test/test_merge.jl
@@ -1,0 +1,41 @@
+using Test
+
+import CLIMAParameters as CP
+
+@testset "Merge correctness" begin
+
+    FT = Float64
+    toml_1 = ("toml/merge1.toml")
+    toml_2 = ("toml/merge2.toml")
+
+    toml_dict_1 = CP.create_toml_dict(FT, default_file = toml_1)
+    toml_dict_2 = CP.create_toml_dict(FT, default_file = toml_2)
+
+    # Test individual TOMLs
+    a_1 = CP.get_parameter_values(toml_dict_1, "a")[2]
+    a_2 = CP.get_parameter_values(toml_dict_2, "a")[2]
+    @test a_1 == 0.0
+    @test a_1 isa FT
+    @test a_2 == 2
+    @test a_2 isa Int
+
+    # Test merging
+    merged_dict = CP.merge_toml_files([toml_1, toml_2]; override = true)
+    merged_toml_dict = CP.create_toml_dict(FT, default_file = merged_dict)
+    merged_a = CP.get_parameter_values(merged_toml_dict, "a")[2]
+    @test merged_a == 2
+    @test merged_a isa Int
+    merged_b = CP.get_parameter_values(merged_toml_dict, "b")[2]
+    @test merged_b == 3.0
+    @test merged_b isa FT
+
+    # Swap merge order
+    merged_dict = CP.merge_toml_files([toml_2, toml_1]; override = true)
+    merged_toml_dict = CP.create_toml_dict(FT, default_file = merged_dict)
+    merged_a = CP.get_parameter_values(merged_toml_dict, "a")[2]
+    @test merged_a == 0.0
+    @test merged_a isa FT
+    merged_b = CP.get_parameter_values(merged_toml_dict, "b")[2]
+    @test merged_b == 3.0
+    @test merged_b isa FT
+end

--- a/test/toml/merge1.toml
+++ b/test/toml/merge1.toml
@@ -1,0 +1,4 @@
+[a]
+value = 0
+type = "float"
+alias = "a"

--- a/test/toml/merge2.toml
+++ b/test/toml/merge2.toml
@@ -1,0 +1,9 @@
+[a]
+value = 2
+type = "integer"
+alias = "a"
+
+[b]
+value = 3
+type = "float"
+alias = "b"

--- a/test/toml_consistency.jl
+++ b/test/toml_consistency.jl
@@ -1,8 +1,6 @@
 using Test
 
-# import CLIMAParameters
-import CLIMAParameters
-const CP = CLIMAParameters
+import CLIMAParameters as CP
 
 # read parameters needed for tests
 full_parameter_set = CP.create_toml_dict(Float64; dict_type = "alias")

--- a/test/types_from_file.jl
+++ b/test/types_from_file.jl
@@ -1,10 +1,8 @@
+using Test
 
-# import CLIMAParameters
-import CLIMAParameters
-const CP = CLIMAParameters
+import CLIMAParameters as CP
 
 path_to_params = joinpath(@__DIR__, "toml", "typed_parameters.toml")
-
 
 @testset "parameter types from file" begin
 


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
This PR adds a function `merge_toml_files` which will merge multiple TOML files, effectively allowing the user to construct a `toml_dict` from more than 2 TOML files.
This will be useful for using multiple case-specific TOML files in addition to the default TOML file. 
This also does not break any of the existing CP interface.
## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->
- [ ] Add a function which writes a `toml_dict` to a file.

## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->
- More specifically, `merge_toml_files` reads in an arbitrary number of TOML files and merges them into one dictionary.
Overlapping keys are overridden in the order that they are read in and a warning is printed each time an entry is overwritten.
Then, this dictionary is written to a temporary file and returns the filepath, which can be passed into `create_toml_dict`.
- Tests for this are included as well.
- Cleaned up the imports for the other tests.

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
