### PR TITLE
Make formatter action verbose

### DIFF
--- a/.github/workflows/JuliaFormatter.yml
+++ b/.github/workflows/JuliaFormatter.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Apply JuliaFormatter
       if: steps.filter.outputs.julia_file_change == 'true'
       run: |
-        julia --project=.dev .dev/climaformat.jl .
+        julia --project=.dev .dev/climaformat.jl -v .
 
     - name: Check formatting diff
       if: steps.filter.outputs.julia_file_change == 'true'


### PR DESCRIPTION
This will make it formatting errors like [this one](https://github.com/CliMA/CLIMAParameters.jl/actions/runs/5008884943/jobs/8997815564) clearer.