### PR TITLE
Bump patch version

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CLIMAParameters"
 uuid = "6eacf6c3-8458-43b9-ae03-caf5306d3d53"
 authors = ["Climate Modeling Alliance"]
-version = "0.7.4"
+version = "0.7.5"
 
 [deps]
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"


### PR DESCRIPTION
To use `merge_toml_files` in other packages, a new version needs to be released.