### PR TITLE
Add held-suarez equator-pole temperature gradient

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CLIMAParameters"
 uuid = "6eacf6c3-8458-43b9-ae03-caf5306d3d53"
 authors = ["Climate Modeling Alliance"]
-version = "0.7.5"
+version = "0.7.6"
 
 [deps]
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"

--- a/src/parameters.toml
+++ b/src/parameters.toml
@@ -1553,9 +1553,21 @@ alias = "avogad"
 value = 6.02214076e23
 type = "float"
 
+# Held-Suarez
+
+[equator_pole_temperature_gradient_dry]
+alias = "ΔT_y_dry"
+value = 60
+type = "float"
+description = "Temperature gradient between equator and pole for dry adiabatic atmosphere. See Held and Suarez (1994) https://doi.org/10.1175/1520-0477(1994)075%3C1825:APFTIO%3E2.0.CO;2"
+
+[equator_pole_temperature_gradient_wet]
+alias = "ΔT_y_wet"
+value = 65
+type = "float"
+description = "Temperature gradient between equator and pole for moist adiabatic atmosphere. See Held and Suarez (1994) https://doi.org/10.1175/1520-0477(1994)075%3C1825:APFTIO%3E2.0.CO;2"
 
 # EDMF
-
 
 [EDMF_surface_area]
 alias = "surface_area"


### PR DESCRIPTION
This pair of parameters is currently hardcoded in ClimaAtmos, but we will need to calibrate it soon. It would be nice to add this to the ClimaParameters defaults so I don't need to add an override TOML file in ClimaAtmos just for calibration.