### PR TITLE
Add additional ARG2000 parameters

### DIFF
--- a/src/parameters.toml
+++ b/src/parameters.toml
@@ -1397,10 +1397,25 @@ value = 2.5
 type = "float"
 description = "Scaling coefficient for an empirically determined functional dependence in Abdul-Razzak and Ghan, 2000. Unitless. DOI: https://doi.org/10.1029/1999JD901161"
 
-[ARG2000_g_coeff]
+[ARG2000_g_coeff_1]
+value = 1.0
+type = "float"
+description = "Scaling coefficient for an empirically determined functional dependence in Abdul-Razzak and Ghan, 2000. Unitless. DOI: https://doi.org/10.1029/1999JD901161"
+
+[ARG2000_g_coeff_2]
 value = 0.25
 type = "float"
 description = "Scaling coefficient for an empirically determined functional dependence in Abdul-Razzak and Ghan, 2000. Unitless. DOI: https://doi.org/10.1029/1999JD901161"
+
+[ARG2000_pow_1]
+value = 1.5
+type = "float"
+description = "Power of (zeta / eta) for an empirically determined functional dependence in Abdul-Razzak and Ghan, 2000. Unitless. DOI: https://doi.org/10.1029/1999JD901161"
+
+[ARG2000_pow_2]
+value = 0.75
+type = "float"
+description = "Power of (S_m^2 / (zeta + 3 * eta)) for an empirically determined functional dependence in Abdul-Razzak and Ghan, 2000. Unitless. DOI: https://doi.org/10.1029/1999JD901161"
 
 # Microphysics - Modal aerosol model
 


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
Add an additional coefficient for the `g` function in the ARG2000 aerosol activation scheme, and also include the exponents since they are empirically determined in the scheme.

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->
Replaced `ARG2000_g_coeff` with `ARG2000_g_coeff_1` and `ARG2000_g_coeff_2`
Added `ARG2000_pow_1` and `ARG2000_pow_2`

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
