### PR TITLE
add area limiter and mixing length parameters

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CLIMAParameters"
 uuid = "6eacf6c3-8458-43b9-ae03-caf5306d3d53"
 authors = ["Climate Modeling Alliance"]
-version = "0.7.23"
+version = "0.7.24"
 
 [deps]
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"

--- a/src/parameters.toml
+++ b/src/parameters.toml
@@ -2121,6 +2121,18 @@ value = 1
 type = "float"
 description = "TODO: Remove this. Constant entrainment coefficient used for testing EDMF"
 
+[min_area_limiter_scale]
+alias = "min_area_limiter_scale"
+value = 1e-3
+type = "float"
+description = "Constant coefficient that scales the minimum area limiter term in entrainment. Parameter not described in the literature."
+
+[min_area_limiter_power]
+alias = "min_area_limiter_power"
+value = 10
+type = "float"
+description = "Constant coefficient for the exponent in the minimum area limiter term in entrainment. Parameter not described in the literature."
+
 [detr_tau]
 alias = "detr_tau"
 value = 900
@@ -2138,6 +2150,24 @@ alias = "detr_buoy_coeff"
 value = 0.12
 type = "float"
 description = "Coefficient for the b/w^2 term in the detrainment closure. See Tan et al. (2018) [https://doi.org/10.1002/2017MS001162], Eq 27."
+
+[max_area_limiter_scale]
+alias = "max_area_limiter_scale"
+value = 0.1
+type = "float"
+description = "Constant coefficient that scales the maximum area limiter term in detrainment. Parameter not described in the literature."
+
+[max_area_limiter_power]
+alias = "max_area_limiter_power"
+value = 10
+type = "float"
+description = "Constant coefficient for the exponent in the maximum area limiter term in detrainment. Parameter not described in the literature."
+
+[c_smag]
+alias = "c_smag"
+value = 0.2
+type = "float"
+description = "Smagorinsky coefficient"
 
 [EDMF_surface_area]
 alias = "surface_area"
@@ -2216,6 +2246,12 @@ alias = "l_max"
 value = 1.0e6
 type = "float"
 description = "Upper limit for length scale limiter in mixing length closure. See Lopez-Gomez et al. (2020) [https://doi.org/10.1029/2020MS002161]."
+
+[mixing_length_l_min]
+alias = "l_min"
+value = 10
+type = "float"
+description = "Lower limit for mixing length. Parameter not described in the literature."
 
 [entrainment_factor]
 alias = "entrainment_factor"


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
Adds some parameters that are needed for area fraction limiter in entrainment and detrainment. Also adds Smagorinsky coefficient and minimum mixing lenght.

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
