### PR TITLE
Update default value for alpha_rayleigh_uh

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CLIMAParameters"
 uuid = "6eacf6c3-8458-43b9-ae03-caf5306d3d53"
 authors = ["Climate Modeling Alliance"]
-version = "0.8.1"
+version = "0.8.2"
 
 [deps]
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"

--- a/src/parameters.toml
+++ b/src/parameters.toml
@@ -1648,7 +1648,7 @@ type = "float"
 description = "rayleigh sponge vert velocity coeff"
 
 [alpha_rayleigh_uh]
-value = 0.0001
+value = 0.0
 type = "float"
 description = "rayleigh sponge horizontal velocity coefficient"
 


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
We want the default value for `alpha_rayleigh_uh` to be zero. This was missed in ClimaAtmos PR[#2021](https://github.com/CliMA/ClimaAtmos.jl/pull/2021) I think. This PR also bumps patch version.

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
