### PR TITLE
Rename to ClimaParams.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,4 +1,4 @@
-name = "ClimaParameters"
+name = "ClimaParams"
 uuid = "5c42b081-d73a-476f-9059-fd94b934656c"
 authors = ["Climate Modeling Alliance"]
 version = "0.10.0"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ClimaParameters.jl
+# ClimaParams.jl
 
 Contains all universal constants and physical parameters in the [CliMA ecosystem](https://github.com/CliMA).
 
@@ -9,15 +9,15 @@ Contains all universal constants and physical parameters in the [CliMA ecosystem
 | **GHA CI**           | [![gha ci][gha-ci-img]][gha-ci-url]           |
 | **Code Coverage**    | [![codecov][codecov-img]][codecov-url]        |
 
-[docs-bld-img]: https://github.com/CliMA/ClimaParameters.jl/actions/workflows/Docs.yml/badge.svg
-[docs-bld-url]: https://github.com/CliMA/ClimaParameters.jl/actions/workflows/Docs.yml
+[docs-bld-img]: https://github.com/CliMA/ClimaParams.jl/actions/workflows/Docs.yml/badge.svg
+[docs-bld-url]: https://github.com/CliMA/ClimaParams.jl/actions/workflows/Docs.yml
 
 [docs-dev-img]: https://img.shields.io/badge/docs-dev-blue.svg
-[docs-dev-url]: https://CliMA.github.io/ClimaParameters.jl/dev/
+[docs-dev-url]: https://CliMA.github.io/ClimaParams.jl/dev/
 
-[gha-ci-img]: https://github.com/CliMA/ClimaParameters.jl/actions/workflows/ci.yml/badge.svg
-[gha-ci-url]: https://github.com/CliMA/ClimaParameters.jl/actions/workflows/ci.yml
+[gha-ci-img]: https://github.com/CliMA/ClimaParams.jl/actions/workflows/ci.yml/badge.svg
+[gha-ci-url]: https://github.com/CliMA/ClimaParams.jl/actions/workflows/ci.yml
 
-[codecov-img]: https://codecov.io/gh/CliMA/ClimaParameters.jl/branch/main/graph/badge.svg
-[codecov-url]: https://codecov.io/gh/CliMA/ClimaParameters.jl
+[codecov-img]: https://codecov.io/gh/CliMA/ClimaParams.jl/branch/main/graph/badge.svg
+[codecov-url]: https://codecov.io/gh/CliMA/ClimaParams.jl
 

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,5 +1,5 @@
 [deps]
-ClimaParameters = "5c42b081-d73a-476f-9059-fd94b934656c"
+ClimaParams = "5c42b081-d73a-476f-9059-fd94b934656c"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 
 [compat]

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,4 +1,4 @@
-using ClimaParameters, Documenter
+using ClimaParams, Documenter
 
 pages = Any[
     "Home" => "index.md",
@@ -23,17 +23,17 @@ format = Documenter.HTML(
 )
 
 makedocs(
-    sitename = "ClimaParameters.jl",
+    sitename = "ClimaParams.jl",
     format = format,
     clean = true,
     checkdocs = :exports,
     strict = true,
-    modules = [ClimaParameters],
+    modules = [ClimaParams],
     pages = pages,
 )
 
 deploydocs(
-    repo = "github.com/CliMA/ClimaParameters.jl.git",
+    repo = "github.com/CliMA/ClimaParams.jl.git",
     target = "build",
     push_preview = true,
     devbranch = "main",

--- a/docs/src/API.md
+++ b/docs/src/API.md
@@ -1,7 +1,7 @@
 # API
 
 ```@meta
-CurrentModule = ClimaParameters
+CurrentModule = ClimaParams
 ```
 
 ## Parameter dictionaries

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,14 +1,14 @@
-# ClimaParameters.jl
+# ClimaParams.jl
 
 This package contains all of the parameters used across the [CliMA](https://github.com/CliMA) organization. Some parameters are simply global constants (e.g., speed of light), while others are parameters that may be tuned in a machine-learning layer that sits on-top of the climate model.
 
-## What parameters are good candidates for ClimaParameters?
+## What parameters are good candidates for ClimaParams?
 
-ClimaParameters serve several functionalities and require certain attributes. A parameter is a good candidate for ClimaParameters if it has _all_ of the following attributes:
+ClimaParams serve several functionalities and require certain attributes. A parameter is a good candidate for ClimaParams if it has _all_ of the following attributes:
 
  - The parameter does not vary in space
  - The parameter does not vary in time (per climate simulation)
- - The parameter is a function of only constants other ClimaParameters and or constants
+ - The parameter is a function of only constants other ClimaParams and or constants
 
 ## Getting Started
 
@@ -16,7 +16,7 @@ The basic flow is as follows:
 1. Create the parameter dictionary with your desired floating point type
 2. Retrieve parameters
 ```julia
-import ClimaParameters as CP
+import ClimaParams as CP
 param_dict = CP.create_toml_dict(Float64)
 params = CP.get_parameter_values(param_dict, ["gravitational_acceleration", "planet_radius"])
 ```

--- a/docs/src/param_retrieval.md
+++ b/docs/src/param_retrieval.md
@@ -7,7 +7,7 @@ There are two keys functions for parameter retrieval:
 To construct a TOML dictionary, pass in the desired floating point type. 
 This will source parameter values from the global default list stored in `src/parameters.toml`
 ```julia
-import ClimaParameters as CP
+import ClimaParams as CP
 toml_dict = CP.create_toml_dict(Float64)
 ```
 To retrieve parameters, pass in the TOML dictionary and the names that match the default parameters.
@@ -52,7 +52,7 @@ params = CP.get_parameter_values(toml_dict, :gravitational_acceleration => :g,
 
 #### In the user-facing driver file
 ```julia
-import ClimaParameters
+import ClimaParams
 using Thermodynamics
 
 thermo_params = ThermodynamicsParameters(Float64)
@@ -90,7 +90,7 @@ function ThermodynamicsParameters(toml_dict)
         ...
     ]
 
-    parameters = ClimaParameters.get_parameter_values(
+    parameters = ClimaParams.get_parameter_values(
         toml_dict,
         name_map,
         "Thermodynamics",
@@ -114,12 +114,12 @@ end
 Here we build a `CloudMicrophysics` parameter set. In this case, the user wishes to use a
 0-moment microphysics parameterization scheme.
 ```julia
-import ClimaParameters
+import ClimaParams
 import Thermodynamics
 import CloudMicrophysics
 
 #load defaults
-toml_dict = ClimaParameters.create_toml_dict(Float64)
+toml_dict = ClimaParams.create_toml_dict(Float64)
 
 #build the low level parameter set
 param_therm = Thermodynamics.Parameters.ThermodynamicsParameters(toml_dict)
@@ -169,7 +169,7 @@ function CloudMicrophysicsParameters(
 
     parameter_names = [ "K_therm", ... ]
 
-    parameters  = ClimaParameters.get_parameter_values(
+    parameters  = ClimaParams.get_parameter_values(
         toml_dict,
         parameter_names,
         "CloudMicrophysics",

--- a/docs/src/toml.md
+++ b/docs/src/toml.md
@@ -2,7 +2,7 @@
 
 The complete user interface consists of two files in `TOML` format
 1. A user-defined experiment file - in the local experiment directory
-2. A defaults file - in `src/` directory of `ClimaParameters.jl`
+2. A defaults file - in `src/` directory of `ClimaParams.jl`
 
 ## Parameter style-guide
 
@@ -80,7 +80,7 @@ Here, the `value` field has been overwritten by the experiment value.
 
 ## File and parameter interaction with CliMA
 
-`ClimaParameters.jl` provides several methods to parse, merge, and log parameter information.
+`ClimaParams.jl` provides several methods to parse, merge, and log parameter information.
 
 ### Loading from file
 We provide the following methods to load parameters from file
@@ -92,11 +92,11 @@ The `Float64` (or `Float32`) defines the requested precision of the returned par
 
 Typical usage involves passing the local parameter file
 ```julia
-import ClimaParameters
+import ClimaParams
 local_experiment_file = joinpath(@__DIR__,"local_exp_parameters.toml")
-toml_dict = ClimaParameters.create_toml_dict(; override_file = local_experiment_file)
+toml_dict = ClimaParams.create_toml_dict(; override_file = local_experiment_file)
 ```
-If no file is passed it will use only the defaults from `ClimaParameters.jl` (causing errors if required parameters are not within this list).
+If no file is passed it will use only the defaults from `ClimaParams.jl` (causing errors if required parameters are not within this list).
 
 You can also pass Julia `Dicts` directly to `override_filepath` and `default_filepath`.
 
@@ -118,7 +118,7 @@ therm_params = Thermodynamics.ThermodynamicsParameters(toml_dict)
 #... build(thermodynamics model,therm_params)
 
 log_file = joinpath(@__DIR__,"parameter_log.toml")
-ClimaParameters.log_parameter_information(toml_dict,log_file)
+ClimaParams.log_parameter_information(toml_dict,log_file)
 
 # ... run(thermodynamics_model)
 ```

--- a/src/ClimaParams.jl
+++ b/src/ClimaParams.jl
@@ -1,4 +1,4 @@
-module ClimaParameters
+module ClimaParams
 
 using TOML
 using DocStringExtensions

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,5 +1,5 @@
 [deps]
-ClimaParameters = "5c42b081-d73a-476f-9059-fd94b934656c"
+ClimaParams = "5c42b081-d73a-476f-9059-fd94b934656c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Thermodynamics = "b60c26fb-14c3-4610-9d3e-2d17fe7ff00c"
 

--- a/test/param_boxes.jl
+++ b/test/param_boxes.jl
@@ -2,7 +2,7 @@ module ParameterBoxes
 
 using Test
 
-import ClimaParameters as CP
+import ClimaParams as CP
 
 Base.@kwdef struct ParameterBox{FT}
     molmass_dryair::FT

--- a/test/test_map.jl
+++ b/test/test_map.jl
@@ -1,5 +1,5 @@
 using Test
-import ClimaParameters as CP
+import ClimaParams as CP
 import Thermodynamics.Parameters.ThermodynamicsParameters
 
 @testset "name map tests" begin

--- a/test/test_merge.jl
+++ b/test/test_merge.jl
@@ -1,6 +1,6 @@
 using Test
 
-import ClimaParameters as CP
+import ClimaParams as CP
 
 @testset "Merge correctness" begin
 

--- a/test/test_tags.jl
+++ b/test/test_tags.jl
@@ -1,4 +1,4 @@
-import ClimaParameters as CP
+import ClimaParams as CP
 using Test
 
 override_file = joinpath("toml", "tags.toml")

--- a/test/toml_consistency.jl
+++ b/test/toml_consistency.jl
@@ -1,6 +1,6 @@
 using Test
 
-import ClimaParameters as CP
+import ClimaParams as CP
 
 # read parameters needed for tests
 full_parameter_set = CP.create_toml_dict(Float64)

--- a/test/types_from_file.jl
+++ b/test/types_from_file.jl
@@ -1,6 +1,6 @@
 using Test
 
-import ClimaParameters as CP
+import ClimaParams as CP
 
 path_to_params = joinpath(@__DIR__, "toml", "typed_parameters.toml")
 


### PR DESCRIPTION
Since we cannot rename ClimaParameters to CLIMAParameters (see [here](https://github.com/JuliaRegistries/General/pull/101489#issuecomment-1960481159)), let's rename the repo to ClimaParams