### PR TITLE
feat: add microphysics parameters for local rime density parameterization in P3 scheme

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,11 @@
 ClimaParams.jl Release Notes
 ========================
 
+v0.10.34
+--------
+- Add parameters for P3 scheme ([#235](https://github.com/CliMA/ClimaParams.jl/pull/235))
+- Remove duplicate parameters for SB2006 ventilation parameterization ([#234](https://github.com/CliMA/ClimaParams.jl/pull/234))
+
 v0.10.31
 --------
 - Add parameters for detrainment ramp and ustar^3 surface tke flux formulation. ([#231](https://github.com/CliMA/ClimaParams.jl/pull/231))

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ClimaParams"
 uuid = "5c42b081-d73a-476f-9059-fd94b934656c"
 authors = ["Climate Modeling Alliance"]
-version = "0.10.33"
+version = "0.10.34"
 
 [deps]
 TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"

--- a/src/parameters.toml
+++ b/src/parameters.toml
@@ -1650,6 +1650,21 @@ value = 3.0
 type = "float"
 description = "Value of μ for constant slope parameterization in P3 scheme. Units: [-]"
 
+[CL1993_local_rime_density_constant_coeff]
+value = 51
+type = "float"
+description = "Constant coefficient for local rime density in P3 scheme. Units: [kg / m³]. See Eq. (17) in Cober and List (1993), DOI: 10.1175/1520-0469(1993)050<1591:MOTHAM>2.0.CO;2"
+
+[CL1993_local_rime_density_linear_coeff]
+value = 114
+type = "float"
+description = "Linear coefficient for local rime density in P3 scheme. Units: [kg / m³ / (m² / s / °C)]. See Eq. (17) in Cober and List (1993), DOI: 10.1175/1520-0469(1993)050<1591:MOTHAM>2.0.CO;2"
+
+[CL1993_local_rime_density_quadratic_coeff]
+value = -5.5
+type = "float"
+description = "Quadratic coefficient for local rime density in P3 scheme. Units: [kg / m³ / (m² / s / °C)²]. See Eq. (17) in Cober and List (1993), DOI: 10.1175/1520-0469(1993)050<1591:MOTHAM>2.0.CO;2"
+
 # Microphysics - temperature dependant, aerosol independant immerson freezing
 
 [Frostenberg2023_standard_deviation]


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
- add parameters for local rime density in P3 scheme:
    - CL1993_local_rime_density_constant_coeff
    - CL1993_local_rime_density_linear_coeff
    - CL1993_local_rime_density_quadratic_coeff

To be used in https://github.com/CliMA/CloudMicrophysics.jl/pull/596

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
