### PR TITLE
Log parameter when getindex is called

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 ClimaParams.jl Release Notes
 ========================
+main
+--------
+- Log parameter when getindex is called ([#243](https://github.com/CliMA/ClimaParams.jl/pull/243))
+
 
 v0.12.0
 --------

--- a/src/file_parsing.jl
+++ b/src/file_parsing.jl
@@ -68,10 +68,12 @@ function Base.getindex(pd::ParamDict, i)
     isnothing(param_type) && error("No type found for parameter `$i`")
 
     if param_value isa AbstractVector
-        return map(x -> _get_typed_value(pd, x, i, param_type), param_value)
+        val = map(x -> _get_typed_value(pd, x, i, param_type), param_value)
     else
-        return _get_typed_value(pd, param_value, i, param_type)
+        val = _get_typed_value(pd, param_value, i, param_type)
     end
+    log_component!(pd, (i,), "getindex")
+    return val
 end
 
 """

--- a/test/test_merge.jl
+++ b/test/test_merge.jl
@@ -25,6 +25,10 @@ import ClimaParams as CP
     @test toml_dict_2["a"] == 2
     @test toml_dict_2["a"] isa Int
 
+    # Test if parameter is logged by getindex
+    @test isnothing(CP.check_override_parameter_usage(toml_dict_1, true))
+    @test isnothing(CP.check_override_parameter_usage(toml_dict_2, true))
+
     # Test merging
     merged_dict = CP.merge_toml_files([toml_1, toml_2]; override = true)
     merged_toml_dict = CP.create_toml_dict(FT, default_file = merged_dict)


### PR DESCRIPTION
This PR logs the parameter when `getindex` is called. This allows for `check_override_parameter_usage` to be used, but with a somewhat unhelpful component being `getindex`.