### PR TITLE
Tr/datetime

### DIFF
--- a/docs/src/param_retrieval.md
+++ b/docs/src/param_retrieval.md
@@ -349,10 +349,10 @@ end
 
 ClimaParams supports several parameter types:
 
-- **Float**: Numeric values (default)
-- **Integer**: Whole numbers
-- **String**: Text values  
-- **Bool**: Boolean values
+- **float**: Numeric values (default)
+- **integer**: Whole numbers
+- **string**: Text values
+- **bool**: Boolean values
 - **datetime**: DateTime - an RFC 3339 formatted date-time with the offset omitted or an offset of `z`
 
 The type is specified in the TOML file:


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 

PR #248 added DateTime support to the file parsing, but did not add an entry in the docs. This PR adds an entry for it, and also changes the other parameter types in the docs to lowercase, to reflect the strings the parser is checking for. 



<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
