### PR TITLE
Correction of epoch_time (by 1 minute) and removal of redundant parameter

### DIFF
--- a/src/parameters.toml
+++ b/src/parameters.toml
@@ -2333,9 +2333,9 @@ type = "float"
 description = "Total solar irradiance (TSI) at the mean orbital distance (W m⁻²)."
 
 [epoch_time]
-value = 2000-01-01T11:58:56.816
+value = 2000-01-01T11:58:55.816
 type = "datetime"
-description = "J2000 epoch (Jan 1, 2000 11:58:56.816 UTC) as a DateTime"
+description = "J2000 epoch (Jan 1, 2000 11:58:55.816 UTC) as a DateTime"
 
 [mean_anomaly_at_epoch]
 value = 6.24006014121
@@ -2356,11 +2356,6 @@ description = "Longitude of perihelion at epoch (radians). Corresponds to 282.93
 value = 0.016708634
 type = "float"
 description = "Orbital eccentricity at epoch (unitless)."
-
-[longitude_perihelion]
-value = 4.938188299449
-type = "float"
-description = "Longitude of perihelion (radians). Corresponds to 282.9373°."
 
 # Universal Physical Constants
 


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
This PR corrects the `epoch_time` (it was off by one second) and removes the redundant `longitude_perihelion` parameter (which does not seem to be used anywhere)

The correction of the epoch_time should only lead to minute (pun fully intended) changes in insolation, without a measureable impact on simulations. 


## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


Review checklist

I have:
x followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
x followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
x followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
x checked that this PR does not duplicate an open PR.

----
- [x] I have read and checked the items on the review checklist.
