### PR TITLE
add method of create_toml_dict with multiple override files

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ClimaParams"
 uuid = "5c42b081-d73a-476f-9059-fd94b934656c"
 authors = ["Climate Modeling Alliance"]
-version = "1.0.2"
+version = "1.0.3"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/docs/src/toml.md
+++ b/docs/src/toml.md
@@ -120,7 +120,9 @@ local_experiment_file = joinpath(@__DIR__, "local_exp_parameters.toml")
 toml_dict = ClimaParams.create_toml_dict(FT; override_file = local_experiment_file)
 ```
 
-If `override_file` is omitted, only the default parameters are loaded. You can also pass Julia `Dict`s directly instead of file paths. To combine more than two files, see the API for `merge_toml_files`.
+If `override_file` is omitted, only the default parameters are loaded. You can also pass Julia `Dict`s directly instead of file paths. To combine more than two files, see the API for `merge_toml_files`
+or pass a vector of filepaths to `create_toml_dict` as the kwarg `override_files`.
+They will be merged in the order they are provided.
 
 ### 2. Using and Logging Parameters
 

--- a/test/test_merge.jl
+++ b/test/test_merge.jl
@@ -46,4 +46,20 @@ import ClimaParams as CP
     @test a isa FT
     @test b == 3.0
     @test b isa FT
+
+    # Test merging in create_toml_dict
+    merged_toml_dict = CP.create_toml_dict(FT, toml_1, toml_2)
+    (; a, b) = CP.get_parameter_values(merged_toml_dict, ["a", "b"])
+    @test a == 2
+    @test a isa Int
+    @test b == 3.0
+    @test b isa FT
+
+    # Test merging in create_toml_dict with swapped order
+    merged_toml_dict = CP.create_toml_dict(FT, toml_2, toml_1)
+    (; a, b) = CP.get_parameter_values(merged_toml_dict, ["a", "b"])
+    @test a == 0.0
+    @test a isa FT
+    @test b == 3.0
+    @test b isa FT
 end


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Adds a short helper method of `create_toml_dict` that makes a toml dict from a vector of override files. This is something that was implemented in ClimaLand here. I want to do something similar in ClimaCoupler, so I figured the method should live here rather than being duplicated in multiple repos.

## To-do
- [x] add new method of `create_toml_dict`
- [x] add tests
- [x] update docs
- [x] tag v1.0.3 to use this downstream

