### PR TITLE
Update area limiter coeffs

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ClimaParams"
 uuid = "5c42b081-d73a-476f-9059-fd94b934656c"
 authors = ["Climate Modeling Alliance"]
-version = "1.0.15"
+version = "1.0.16"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/parameters.toml
+++ b/src/parameters.toml
@@ -2758,12 +2758,12 @@ description = "Coefficient for the vertical divergence term in the entrainment c
 [min_area_limiter_scale]
 value = 0.001
 type = "float"
-description = "Scaling coefficient for the minimum area limiter in entrainment (unitless)."
+description = "Rate coefficient for the minimum area fraction limiter in entrainment (s⁻¹)."
 
 [min_area_limiter_power]
-value = 10
+value = 1
 type = "float"
-description = "Exponent for the minimum area limiter in entrainment (unitless)."
+description = "Exponent for the minimum area fraction limiter in both entrainment and detrainment (unitless)."
 
 [entr_detr_limit_inv_tau]
 value = 0.0001
@@ -2784,6 +2784,11 @@ description = "Coefficient for the $w$ term in the detrainment closure (unitless
 value = 0.12
 type = "float"
 description = "Coefficient for the $b/w^2$ term in the detrainment closure (unitless). Source: Tan et al. (2018), Eq. 27."
+
+[detr_buoy_inv_tau_max]
+value = 0.01
+type = "float"
+description = "Maximum allowed inverse buoyancy time scale (s⁻¹), used to limit detrainment when velocity differences become small and prevent excessively fast detrainment."
 
 [detr_vertdiv_coeff]
 value = 1
@@ -2806,14 +2811,14 @@ type = "float"
 description = "Factor for calculating the steepness of the sigmoid ramp for the detrainment top limiter. Steepness = factor / (z_end - z_start)."
 
 [max_area_limiter_scale]
-value = 0.1
+value = 0.001
 type = "float"
-description = "Scaling coefficient for the maximum area limiter in detrainment (unitless)."
+description = "Rate coefficient for the maximum area fraction limiter in detrainment (s⁻¹)."
 
 [max_area_limiter_power]
-value = 10
+value = 1
 type = "float"
-description = "Exponent for the maximum area limiter in detrainment (unitless)."
+description = "Exponent for the maximum area fraction limiter in detrainment (unitless)."
 
 [c_smag]
 value = 0.2


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Update area fraction limiter coeffs because the functions in ClimaAtmos have been changed from exp to power laws. Also add a parameter for maximum buoyancy detrainment inverse timescale.

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- I have read and checked the items on the review checklist.
