### PR TITLE
Update JuliaFormatter to v2.10.1

### DIFF
--- a/.github/workflows/JuliaFormatter.yml
+++ b/.github/workflows/JuliaFormatter.yml
@@ -12,5 +12,5 @@ jobs:
     steps:
       - uses: julia-actions/julia-format@v4
         with:
-          version: '1' # Set `version` to '1.0.54' if you need to use JuliaFormatter.jl v1.0.54 (default: '1')
+          version: '2.10.1'
           suggestion-label: 'format-suggest' # leave this unset or empty to show suggestions for all PRs


### PR DESCRIPTION
This PR updates JuliaFormatter to v2.10.1 and pins it. This is recommended by https://juliaeditorsupport.github.io/JuliaFormatter.jl/stable/status/#Pinning-the-JuliaFormatter-version.